### PR TITLE
fix: Skip group example tests on Free

### DIFF
--- a/internal/provider/group_v2_resource_test.go
+++ b/internal/provider/group_v2_resource_test.go
@@ -68,7 +68,7 @@ func TestAccGroupV2Resource(t *testing.T) {
 }
 
 func TestAccGroupV2ExampleResource(t *testing.T) {
-
+	test.CheckEnterpriseEnabled(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
To unlock [dependabot PRs](https://github.com/conduktor/terraform-provider-conduktor/actions/runs/10998050752/job/30535173165?pr=4#step:8:667) that can't access secrets, skip example tests for groups when a license is not set.