### PR TITLE
Update to latest Conduktor console and CLI

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-CONDUKTOR_CONSOLE_IMAGE=conduktor/conduktor-console:1.27.0
-CONDUKTOR_CONSOLE_CORTEX_IMAGE=conduktor/conduktor-console-cortex:1.27.0
+CONDUKTOR_CONSOLE_IMAGE=conduktor/conduktor-console:1.28.0
+CONDUKTOR_CONSOLE_CORTEX_IMAGE=conduktor/conduktor-console-cortex:1.28.0
 CDK_BASE_URL=http://localhost:8080
 CDK_ADMIN_EMAIL=admin@conduktor.io
 CDK_ADMIN_PASSWORD=test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,9 +71,9 @@ jobs:
           - version: "1.9.*"
             name: "TF-1.9"
         console:
-          - "1.25.0"
           - "1.26.0"
           - "1.27.0"
+          - "1.28.0"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23
 toolchain go1.23.0
 
 require (
-	github.com/conduktor/ctl v0.3.0
+	github.com/conduktor/ctl v0.3.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-resty/resty/v2 v2.15.3
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/conduktor/ctl v0.3.0 h1:dj/8S+dmPht11UPhuMdgwNzwg3rVu+6IM6PVSpRcSwY=
-github.com/conduktor/ctl v0.3.0/go.mod h1:/K64DhqaRSOXULuwy9nR5xUxFvfEtKJ+/PCuPrg+Frk=
+github.com/conduktor/ctl v0.3.1 h1:YjAQEVcI9UMDwh8j+yKKNg5gdgBGYtpY5fQuR38ZIAk=
+github.com/conduktor/ctl v0.3.1/go.mod h1:/K64DhqaRSOXULuwy9nR5xUxFvfEtKJ+/PCuPrg+Frk=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/provider/generic_resource.go
+++ b/internal/provider/generic_resource.go
@@ -69,7 +69,7 @@ func (r *GenericResource) Create(ctx context.Context, req resource.CreateRequest
 	tflog.Info(ctx, fmt.Sprintf("Create %s kind named %s", data.Kind.String(), data.Name.String()))
 	tflog.Trace(ctx, fmt.Sprintf("Create resource with TF data: %+v", data))
 
-	cliResource, err := ctlresource.FromYamlByte([]byte(data.Manifest.ValueString()))
+	cliResource, err := ctlresource.FromYamlByte([]byte(data.Manifest.ValueString()), true)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Model Error", fmt.Sprintf("Unable to create Generic, got error: %s", err))
@@ -120,7 +120,7 @@ func (r *GenericResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	cliResource, err := ctlresource.FromYamlByte(get)
+	cliResource, err := ctlresource.FromYamlByte(get, true)
 	if err != nil {
 		resp.Diagnostics.AddError("Model Error", fmt.Sprintf("Unable to read Generic resource, got error: %s", err))
 		return
@@ -166,7 +166,7 @@ func (r *GenericResource) Update(ctx context.Context, req resource.UpdateRequest
 	tflog.Info(ctx, fmt.Sprintf("Update %s kind named %s", data.Kind.String(), data.Name.String()))
 	tflog.Trace(ctx, fmt.Sprintf("Update resource with TF data: %+v", data))
 
-	cliResource, err := ctlresource.FromYamlByte([]byte(data.Manifest.ValueString()))
+	cliResource, err := ctlresource.FromYamlByte([]byte(data.Manifest.ValueString()), true)
 	if err != nil {
 		resp.Diagnostics.AddError("Model Error", fmt.Sprintf("Unable to create Generic, got error: %s", err))
 		return


### PR DESCRIPTION
Update tests with Conduktor Console [1.28.0](https://docs.conduktor.io/changelog/#console-1280)
Update Conduktor CLI dependency to [v0.3.1](https://github.com/conduktor/ctl/releases/tag/v0.3.1)