### PR TITLE
chore: Update console to 1.29.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-CONDUKTOR_CONSOLE_IMAGE=conduktor/conduktor-console:1.28.0
-CONDUKTOR_CONSOLE_CORTEX_IMAGE=conduktor/conduktor-console-cortex:1.28.0
+CONDUKTOR_CONSOLE_IMAGE=conduktor/conduktor-console:1.29.0
+CONDUKTOR_CONSOLE_CORTEX_IMAGE=conduktor/conduktor-console-cortex:1.29.0
 CDK_BASE_URL=http://localhost:8080
 CDK_ADMIN_EMAIL=admin@conduktor.io
 CDK_ADMIN_PASSWORD=testP4ss!

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
           - "1.26.0"
           - "1.27.0"
           - "1.28.0"
+          - "1.29.0"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
           CONDUKTOR_CONSOLE_CORTEX_IMAGE: conduktor/conduktor-console-cortex:${{ matrix.console }}
           CDK_BASE_URL: http://localhost:8080
           CDK_ADMIN_EMAIL: admin@conduktor.io
-          CDK_ADMIN_PASSWORD: test
+          CDK_ADMIN_PASSWORD: testP4ss!
           TF_LOG_PROVIDER_CONDUKTOR: DEBUG
         timeout-minutes: 15
         run: |

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-export SHELL:=/bin/bash
+export SHELL:=/bin/sh
 export SHELLOPTS:=$(if $(SHELLOPTS),$(SHELLOPTS):)pipefail:errexit
 
 include .env

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-export SHELL:=/bin/sh
+export SHELL:=/bin/bash
 export SHELLOPTS:=$(if $(SHELLOPTS),$(SHELLOPTS):)pipefail:errexit
 
 include .env

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23
 toolchain go1.23.0
 
 require (
-	github.com/conduktor/ctl v0.3.1
+	github.com/conduktor/ctl v0.3.2
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-resty/resty/v2 v2.16.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/conduktor/ctl v0.3.1 h1:YjAQEVcI9UMDwh8j+yKKNg5gdgBGYtpY5fQuR38ZIAk=
-github.com/conduktor/ctl v0.3.1/go.mod h1:/K64DhqaRSOXULuwy9nR5xUxFvfEtKJ+/PCuPrg+Frk=
+github.com/conduktor/ctl v0.3.2 h1:Yqj5XK60SbKVoTK1ms4KyWrkZ0xbL4p4I6FBHuDd2Fg=
+github.com/conduktor/ctl v0.3.2/go.mod h1:/K64DhqaRSOXULuwy9nR5xUxFvfEtKJ+/PCuPrg+Frk=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Update Conduktor CLI to 0.3.2 and Console used for test env to latest [1.29.0](https://docs.conduktor.io/changelog/#console-1290)