### PR TITLE
Ops 570 add gateway api configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,12 @@
 CONDUKTOR_CONSOLE_IMAGE=conduktor/conduktor-console:1.29.0
 CONDUKTOR_CONSOLE_CORTEX_IMAGE=conduktor/conduktor-console-cortex:1.29.0
+CONDUKTOR_GATEWAY_IMAGE=conduktor/conduktor-gateway:3.4.0
 CDK_BASE_URL=http://localhost:8080
 CDK_ADMIN_EMAIL=admin@conduktor.io
 CDK_ADMIN_PASSWORD=testP4ss!
+CDK_GATEWAY_BASE_URL=http://localhost:8888
+CDK_GATEWAY_USER=admin
+CDK_GATEWAY_PASSWORD=conduktor
 CDK_DEBUG=false
 TF_LOG=INFO
 TF_LOG_PROVIDER_CONDUKTOR=INFO

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,8 @@ jobs:
           - "1.27.0"
           - "1.28.0"
           - "1.29.0"
+        gateway:
+          - "3.4.0"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -99,6 +101,7 @@ jobs:
           TESTARGS: "-cover ./internal/provider/"
           CONDUKTOR_CONSOLE_IMAGE: conduktor/conduktor-console:${{ matrix.console }}
           CONDUKTOR_CONSOLE_CORTEX_IMAGE: conduktor/conduktor-console-cortex:${{ matrix.console }}
+          CONDUKTOR_GATEWAY_IMAGE: conduktor/conduktor-gateway:${{ matrix.gateway }}
           CDK_BASE_URL: http://localhost:8080
           CDK_ADMIN_EMAIL: admin@conduktor.io
           CDK_ADMIN_PASSWORD: testP4ss!

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,6 +58,52 @@ services:
     healthcheck:
       test: ["CMD", "/opt/conduktor/scripts/healthcheck.sh"]
 
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v22.3.11
+    hostname: redpanda
+    command:
+      - redpanda
+      - start
+      - --kafka-addr
+      - internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr
+      - internal://redpanda:9092,external://localhost:19092
+      - --pandaproxy-addr
+      - internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr
+      - internal://redpanda:8082,external://localhost:18082
+      - --schema-registry-addr
+      - internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr
+      - redpanda:33145
+      - --advertise-rpc-addr
+      - redpanda:33145
+      - --smp 1
+      - --memory 1G
+      - --reserve-memory 0M
+      - --overprovisioned
+      - --default-log-level=debug
+    ports:
+      - 18081:18081
+      - 18082:18082
+      - 19092:19092
+      - 19644:9644
+
+  conduktor-gateway:
+    image: ${CONDUKTOR_GATEWAY_IMAGE}
+    hostname: gateway
+    ports:
+      - "9094:9094"
+      - "8888:8888"
+    depends_on:
+      - redpanda
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
+      GATEWAY_ADVERTISED_HOST: gateway
+      GATEWAY_HTTP_PORT: 8888
+      GATEWAY_PORT_START: 9094
+      GATEWAY_PORT_COUNT: 1
+
 volumes:
   pg_data: {}
   conduktor_data: {}

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,9 +45,16 @@ provider "conduktor" {
 - `admin_password` (String, Sensitive) The password of the admin user. May be set using environment variable `CDK_ADMIN_PASSWORD`. Required if admin_email is set. If not provided, the API token will be used to authenticater.
 - `api_token` (String, Sensitive) The API token to authenticate with the Conduktor API. May be set using environment variable `CDK_API_TOKEN` or `CDK_API_KEY`. If not provided, admin_email and admin_password will be used to authenticate. See [documentation](https://docs.conduktor.io/platform/reference/api-reference/#generate-an-api-key) for more information.
 - `cacert` (String) Root CA certificate in PEM format to verify the Conduktor Console certificate. May be set using environment variable `CDK_CACERT`. If not provided, the system's root CA certificates will be used.
-- `cert` (String) Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_CERT`. Must be used with key. If key is provided, cert is required. Useful when Console behind a reverse proxy with client certificate authentication.
+- `cert` (String) Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_CERT`. Must be used with key. If key is provided, cert is required. Useful when Console is behind a reverse proxy with client certificate authentication.
 - `console_url` (String) The URL of the Conduktor Console. May be set using environment variable `CDK_BASE_URL` or `CDK_CONSOLE_URL`. Required either here or in the environment.
+- `gateway_cacert` (String) Root CA certificate in PEM format to verify the Conduktor Gateway certificate. May be set using environment variable `CDK_GATEWAY_CACERT`. If not provided, the system's root CA certificates will be used.
+- `gateway_cert` (String) Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_GATEWAY_CERT`. Must be used with key. If key is provided, cert is required. Useful when Gateway is behind a reverse proxy with client certificate authentication.
+- `gateway_insecure` (Boolean) Skip TLS verification flag. May be set using environment variable `CDK_GATEWAY_INSECURE`.
+- `gateway_key` (String) Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_GATEWAY_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Gateway is behind a reverse proxy with client certificate authentication.
+- `gateway_password` (String, Sensitive) The password of Gateway the admin user. May be set using environment variable `CDK_GATEWAY_PASSWORD`. Required if gateway_url is set.
+- `gateway_url` (String) The URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.
+- `gateway_user` (String) The email of the Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.
 - `insecure` (Boolean) Skip TLS verification flag. May be set using environment variable `CDK_INSECURE`.
-- `key` (String) Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Console behind a reverse proxy with client certificate authentication.
+- `key` (String) Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Console is behind a reverse proxy with client certificate authentication.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,8 +52,8 @@ provider "conduktor" {
 - `gateway_insecure` (Boolean) Skip TLS verification flag. May be set using environment variable `CDK_GATEWAY_INSECURE`.
 - `gateway_key` (String) Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_GATEWAY_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Gateway is behind a reverse proxy with client certificate authentication.
 - `gateway_password` (String, Sensitive) The password of Gateway the admin user. May be set using environment variable `CDK_GATEWAY_PASSWORD`. Required if gateway_url is set.
-- `gateway_url` (String) The URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.
-- `gateway_user` (String) The email of the Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.
+- `gateway_url` (String) The administration URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.
+- `gateway_user` (String) The login of a Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.
 - `insecure` (Boolean) Skip TLS verification flag. May be set using environment variable `CDK_INSECURE`.
 - `key` (String) Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Console is behind a reverse proxy with client certificate authentication.
 

--- a/internal/model/provider_data.go
+++ b/internal/model/provider_data.go
@@ -3,5 +3,6 @@ package model
 import "github.com/conduktor/terraform-provider-conduktor/internal/client"
 
 type ProviderData struct {
-	Client *client.Client
+	ConsoleClient *client.ConsoleClient
+	GatewayClient *client.GatewayClient
 }

--- a/internal/provider/generic_resource.go
+++ b/internal/provider/generic_resource.go
@@ -25,7 +25,7 @@ func NewGenericResource() resource.Resource {
 
 // GenericResource defines the resource implementation.
 type GenericResource struct {
-	client *client.Client
+	client *client.ConsoleClient
 }
 
 func (r *GenericResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -53,7 +53,15 @@ func (r *GenericResource) Configure(ctx context.Context, req resource.ConfigureR
 		return
 	}
 
-	r.client = data.Client
+	if data.ConsoleClient == nil {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Console Client not configured. Please provide client configuration details.",
+		)
+		return
+	}
+
+	r.client = data.ConsoleClient
 }
 
 func (r *GenericResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/generic_resource.go
+++ b/internal/provider/generic_resource.go
@@ -56,7 +56,7 @@ func (r *GenericResource) Configure(ctx context.Context, req resource.ConfigureR
 	if data.ConsoleClient == nil {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			"Console Client not configured. Please provide client configuration details.",
+			"Console Client not configured. Please provide client configuration details for Console API.",
 		)
 		return
 	}

--- a/internal/provider/group_v2_resource.go
+++ b/internal/provider/group_v2_resource.go
@@ -57,7 +57,7 @@ func (r *GroupV2Resource) Configure(ctx context.Context, req resource.ConfigureR
 	if data.ConsoleClient == nil {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			"Console Client not configured. Please provide client configuration details.",
+			"Console Client not configured. Please provide client configuration details for Console API.",
 		)
 		return
 	}

--- a/internal/provider/group_v2_resource.go
+++ b/internal/provider/group_v2_resource.go
@@ -26,7 +26,7 @@ func NewGroupV2Resource() resource.Resource {
 
 // GroupV2Resource defines the resource implementation.
 type GroupV2Resource struct {
-	apiClient *client.Client
+	apiClient *client.ConsoleClient
 }
 
 func (r *GroupV2Resource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -54,7 +54,15 @@ func (r *GroupV2Resource) Configure(ctx context.Context, req resource.ConfigureR
 		return
 	}
 
-	r.apiClient = data.Client
+	if data.ConsoleClient == nil {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Console Client not configured. Please provide client configuration details.",
+		)
+		return
+	}
+
+	r.apiClient = data.ConsoleClient
 }
 
 func (r *GroupV2Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/kafka_cluster_v2_resource.go
+++ b/internal/provider/kafka_cluster_v2_resource.go
@@ -25,7 +25,7 @@ func NewKafkaClusterV2Resource() resource.Resource {
 
 // KafkaClusterV2Resource defines the resource implementation.
 type KafkaClusterV2Resource struct {
-	apiClient *client.Client
+	apiClient *client.ConsoleClient
 }
 
 func (r *KafkaClusterV2Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -53,7 +53,15 @@ func (r *KafkaClusterV2Resource) Configure(_ context.Context, req resource.Confi
 		return
 	}
 
-	r.apiClient = data.Client
+	if data.ConsoleClient == nil {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Console Client not configured. Please provide client configuration details.",
+		)
+		return
+	}
+
+	r.apiClient = data.ConsoleClient
 }
 
 func (r *KafkaClusterV2Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/kafka_cluster_v2_resource.go
+++ b/internal/provider/kafka_cluster_v2_resource.go
@@ -56,7 +56,7 @@ func (r *KafkaClusterV2Resource) Configure(_ context.Context, req resource.Confi
 	if data.ConsoleClient == nil {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			"Console Client not configured. Please provide client configuration details.",
+			"Console Client not configured. Please provide client configuration details for Console API.",
 		)
 		return
 	}

--- a/internal/provider/kafka_connect_v2_resource.go
+++ b/internal/provider/kafka_connect_v2_resource.go
@@ -63,7 +63,7 @@ func (r *KafkaConnectV2Resource) Configure(_ context.Context, req resource.Confi
 	if data.ConsoleClient == nil {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			"Console Client not configured. Please provide client configuration details.",
+			"Console Client not configured. Please provide client configuration details for Console API.",
 		)
 		return
 	}

--- a/internal/provider/kafka_connect_v2_resource.go
+++ b/internal/provider/kafka_connect_v2_resource.go
@@ -32,7 +32,7 @@ func NewKafkaConnectV2Resource() resource.Resource {
 
 // KafkaConnectV2Resource defines the resource implementation.
 type KafkaConnectV2Resource struct {
-	apiClient *client.Client
+	apiClient *client.ConsoleClient
 }
 
 func (r *KafkaConnectV2Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -60,7 +60,15 @@ func (r *KafkaConnectV2Resource) Configure(_ context.Context, req resource.Confi
 		return
 	}
 
-	r.apiClient = data.Client
+	if data.ConsoleClient == nil {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Console Client not configured. Please provide client configuration details.",
+		)
+		return
+	}
+
+	r.apiClient = data.ConsoleClient
 }
 
 func (r *KafkaConnectV2Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -67,10 +67,10 @@ func (p *ConduktorProvider) Configure(ctx context.Context, req provider.Configur
 	cacert := schemaUtils.GetStringConfig(config.Cacert, []string{"CDK_CACERT"})
 	key := schemaUtils.GetStringConfig(config.Key, []string{"CDK_KEY"})
 	insecure := schemaUtils.GetBooleanConfig(config.Insecure, []string{"CDK_INSECURE"}, false)
-	gatewayCert := schemaUtils.GetStringConfig(config.Cert, []string{"CDK_GATEWAY_CERT"})
-	gatewayCacert := schemaUtils.GetStringConfig(config.Cacert, []string{"CDK_GATEWAY_CACERT"})
-	gatewayKey := schemaUtils.GetStringConfig(config.Key, []string{"CDK_GATEWAY_KEY"})
-	gatewayInsecure := schemaUtils.GetBooleanConfig(config.Insecure, []string{"CDK_GATEWAY_INSECURE"}, false)
+	gatewayCert := schemaUtils.GetStringConfig(config.GatewayCert, []string{"CDK_GATEWAY_CERT"})
+	gatewayCacert := schemaUtils.GetStringConfig(config.GatewayCacert, []string{"CDK_GATEWAY_CACERT"})
+	gatewayKey := schemaUtils.GetStringConfig(config.GatewayKey, []string{"CDK_GATEWAY_KEY"})
+	gatewayInsecure := schemaUtils.GetBooleanConfig(config.GatewayInsecure, []string{"CDK_GATEWAY_INSECURE"}, false)
 
 	// Validate mandatory configurations
 	if consoleUrl == "" && gatewayUrl == "" {
@@ -101,8 +101,8 @@ func (p *ConduktorProvider) Configure(ctx context.Context, req provider.Configur
 	if gatewayUrl != "" && (gatewayUser == "" || gatewayPassword == "") {
 		details := "The provider cannot create the Gateway API client as there is a missing or empty value for the admin email/password. " +
 			"Set both : " +
-			" - the gateway_admin_login value in the configuration or use the CDK_GATEWAY_USER environment variable. " +
-			" - the gateway_admin_password value in the configuration or use the CDK_GATEWAY_PASSWORD environment variable. " +
+			" - the gateway_user value in the configuration or use the CDK_GATEWAY_USER environment variable. " +
+			" - the gateway_password value in the configuration or use the CDK_GATEWAY_PASSWORD environment variable. " +
 			"If either is already set, ensure the value is not empty."
 
 		resp.Diagnostics.AddAttributeError(path.Root("gateway_user"), "Missing Gateway Admin login", details)
@@ -118,16 +118,16 @@ func (p *ConduktorProvider) Configure(ctx context.Context, req provider.Configur
 	ctx = tflog.SetField(ctx, "admin_email", adminEmail)
 	ctx = tflog.SetField(ctx, "admin_password", adminPassword)
 	ctx = tflog.SetField(ctx, "gateway_url", gatewayUrl)
-	ctx = tflog.SetField(ctx, "gateway_admin_login", gatewayUser)
-	ctx = tflog.SetField(ctx, "gateway_admin_password", gatewayPassword)
+	ctx = tflog.SetField(ctx, "gateway_user", gatewayUser)
+	ctx = tflog.SetField(ctx, "gateway_password", gatewayPassword)
 	ctx = tflog.SetField(ctx, "cert", cert)
 	ctx = tflog.SetField(ctx, "cacert", cacert)
 	ctx = tflog.SetField(ctx, "key", key)
 	ctx = tflog.SetField(ctx, "insecure", insecure)
-	ctx = tflog.SetField(ctx, "gatewayCert", gatewayCert)
-	ctx = tflog.SetField(ctx, "gatewayCacert", gatewayCacert)
-	ctx = tflog.SetField(ctx, "gatewayKey", gatewayKey)
-	ctx = tflog.SetField(ctx, "gatewayIsecure", gatewayInsecure)
+	ctx = tflog.SetField(ctx, "gateway_cert", gatewayCert)
+	ctx = tflog.SetField(ctx, "gateway_cacert", gatewayCacert)
+	ctx = tflog.SetField(ctx, "gateway_key", gatewayKey)
+	ctx = tflog.SetField(ctx, "gateway_insecure", gatewayInsecure)
 	// Avoid leaking sensitive information in logs
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "api_token")
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "admin_password")
@@ -187,8 +187,12 @@ func (p *ConduktorProvider) Configure(ctx context.Context, req provider.Configur
 	resp.DataSourceData = data
 	resp.ResourceData = data
 
-	tflog.Info(ctx, "Configured Conduktor Console client", map[string]any{"success": true})
-	tflog.Info(ctx, "Configured Conduktor Gateway client", map[string]any{"success": true})
+	if consoleApiClient != nil {
+		tflog.Info(ctx, "Configured Conduktor Console client", map[string]any{"success": true})
+	}
+	if gatewayApiClient != nil {
+		tflog.Info(ctx, "Configured Conduktor Gateway client", map[string]any{"success": true})
+	}
 }
 
 func (p *ConduktorProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -136,8 +136,8 @@ func (p *ConduktorProvider) Configure(ctx context.Context, req provider.Configur
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "gatewayKey")
 	tflog.Debug(ctx, "Creating Conduktor Console client")
 
+	// Create Console or Gateway clients only if the respective URL is provided
 	if consoleUrl != "" {
-		// Create client
 		consoleApiClient, err = client.Make(ctx,
 			client.ApiParameter{
 				ApiKey:      apiToken,
@@ -159,7 +159,6 @@ func (p *ConduktorProvider) Configure(ctx context.Context, req provider.Configur
 		}
 	}
 
-	// Create Gateway client only if the URL is provided
 	if gatewayUrl != "" {
 		gatewayApiClient, err = client.MakeGateway(ctx,
 			client.GatewayApiParameters{

--- a/internal/provider/user_v2_resource.go
+++ b/internal/provider/user_v2_resource.go
@@ -26,7 +26,7 @@ func NewUserV2Resource() resource.Resource {
 
 // UserV2Resource defines the resource implementation.
 type UserV2Resource struct {
-	apiClient *client.Client
+	apiClient *client.ConsoleClient
 }
 
 func (r *UserV2Resource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -54,7 +54,15 @@ func (r *UserV2Resource) Configure(ctx context.Context, req resource.ConfigureRe
 		return
 	}
 
-	r.apiClient = data.Client
+	if data.ConsoleClient == nil {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Console Client not configured. Please provide client configuration details.",
+		)
+		return
+	}
+
+	r.apiClient = data.ConsoleClient
 }
 
 func (r *UserV2Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/user_v2_resource.go
+++ b/internal/provider/user_v2_resource.go
@@ -57,7 +57,7 @@ func (r *UserV2Resource) Configure(ctx context.Context, req resource.ConfigureRe
 	if data.ConsoleClient == nil {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			"Console Client not configured. Please provide client configuration details.",
+			"Console Client not configured. Please provide client configuration details for Console API.",
 		)
 		return
 	}

--- a/internal/schema/provider_conduktor/conduktor_provider_gen.go
+++ b/internal/schema/provider_conduktor/conduktor_provider_gen.go
@@ -72,13 +72,13 @@ func ConduktorProviderSchema(ctx context.Context) schema.Schema {
 			},
 			"gateway_url": schema.StringAttribute{
 				Optional:            true,
-				Description:         "The URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.",
-				MarkdownDescription: "The URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.",
+				Description:         "The administration URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.",
+				MarkdownDescription: "The administration URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.",
 			},
 			"gateway_user": schema.StringAttribute{
 				Optional:            true,
-				Description:         "The email of the Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.",
-				MarkdownDescription: "The email of the Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.",
+				Description:         "The login of a Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.",
+				MarkdownDescription: "The login of a Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.",
 			},
 			"insecure": schema.BoolAttribute{
 				Optional:            true,

--- a/internal/schema/provider_conduktor/conduktor_provider_gen.go
+++ b/internal/schema/provider_conduktor/conduktor_provider_gen.go
@@ -36,13 +36,49 @@ func ConduktorProviderSchema(ctx context.Context) schema.Schema {
 			},
 			"cert": schema.StringAttribute{
 				Optional:            true,
-				Description:         "Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_CERT`. Must be used with key. If key is provided, cert is required. Useful when Console behind a reverse proxy with client certificate authentication.",
-				MarkdownDescription: "Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_CERT`. Must be used with key. If key is provided, cert is required. Useful when Console behind a reverse proxy with client certificate authentication.",
+				Description:         "Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_CERT`. Must be used with key. If key is provided, cert is required. Useful when Console is behind a reverse proxy with client certificate authentication.",
+				MarkdownDescription: "Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_CERT`. Must be used with key. If key is provided, cert is required. Useful when Console is behind a reverse proxy with client certificate authentication.",
 			},
 			"console_url": schema.StringAttribute{
 				Optional:            true,
 				Description:         "The URL of the Conduktor Console. May be set using environment variable `CDK_BASE_URL` or `CDK_CONSOLE_URL`. Required either here or in the environment.",
 				MarkdownDescription: "The URL of the Conduktor Console. May be set using environment variable `CDK_BASE_URL` or `CDK_CONSOLE_URL`. Required either here or in the environment.",
+			},
+			"gateway_cacert": schema.StringAttribute{
+				Optional:            true,
+				Description:         "Root CA certificate in PEM format to verify the Conduktor Gateway certificate. May be set using environment variable `CDK_GATEWAY_CACERT`. If not provided, the system's root CA certificates will be used.",
+				MarkdownDescription: "Root CA certificate in PEM format to verify the Conduktor Gateway certificate. May be set using environment variable `CDK_GATEWAY_CACERT`. If not provided, the system's root CA certificates will be used.",
+			},
+			"gateway_cert": schema.StringAttribute{
+				Optional:            true,
+				Description:         "Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_GATEWAY_CERT`. Must be used with key. If key is provided, cert is required. Useful when Gateway is behind a reverse proxy with client certificate authentication.",
+				MarkdownDescription: "Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_GATEWAY_CERT`. Must be used with key. If key is provided, cert is required. Useful when Gateway is behind a reverse proxy with client certificate authentication.",
+			},
+			"gateway_insecure": schema.BoolAttribute{
+				Optional:            true,
+				Description:         "Skip TLS verification flag. May be set using environment variable `CDK_GATEWAY_INSECURE`.",
+				MarkdownDescription: "Skip TLS verification flag. May be set using environment variable `CDK_GATEWAY_INSECURE`.",
+			},
+			"gateway_key": schema.StringAttribute{
+				Optional:            true,
+				Description:         "Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_GATEWAY_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Gateway is behind a reverse proxy with client certificate authentication.",
+				MarkdownDescription: "Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_GATEWAY_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Gateway is behind a reverse proxy with client certificate authentication.",
+			},
+			"gateway_password": schema.StringAttribute{
+				Optional:            true,
+				Sensitive:           true,
+				Description:         "The password of Gateway the admin user. May be set using environment variable `CDK_GATEWAY_PASSWORD`. Required if gateway_url is set.",
+				MarkdownDescription: "The password of Gateway the admin user. May be set using environment variable `CDK_GATEWAY_PASSWORD`. Required if gateway_url is set.",
+			},
+			"gateway_url": schema.StringAttribute{
+				Optional:            true,
+				Description:         "The URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.",
+				MarkdownDescription: "The URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.",
+			},
+			"gateway_user": schema.StringAttribute{
+				Optional:            true,
+				Description:         "The email of the Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.",
+				MarkdownDescription: "The email of the Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.",
 			},
 			"insecure": schema.BoolAttribute{
 				Optional:            true,
@@ -51,20 +87,27 @@ func ConduktorProviderSchema(ctx context.Context) schema.Schema {
 			},
 			"key": schema.StringAttribute{
 				Optional:            true,
-				Description:         "Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Console behind a reverse proxy with client certificate authentication.",
-				MarkdownDescription: "Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Console behind a reverse proxy with client certificate authentication.",
+				Description:         "Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Console is behind a reverse proxy with client certificate authentication.",
+				MarkdownDescription: "Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Console is behind a reverse proxy with client certificate authentication.",
 			},
 		},
 	}
 }
 
 type ConduktorModel struct {
-	AdminEmail    types.String `tfsdk:"admin_email"`
-	AdminPassword types.String `tfsdk:"admin_password"`
-	ApiToken      types.String `tfsdk:"api_token"`
-	Cacert        types.String `tfsdk:"cacert"`
-	Cert          types.String `tfsdk:"cert"`
-	ConsoleUrl    types.String `tfsdk:"console_url"`
-	Insecure      types.Bool   `tfsdk:"insecure"`
-	Key           types.String `tfsdk:"key"`
+	AdminEmail      types.String `tfsdk:"admin_email"`
+	AdminPassword   types.String `tfsdk:"admin_password"`
+	ApiToken        types.String `tfsdk:"api_token"`
+	Cacert          types.String `tfsdk:"cacert"`
+	Cert            types.String `tfsdk:"cert"`
+	ConsoleUrl      types.String `tfsdk:"console_url"`
+	GatewayCacert   types.String `tfsdk:"gateway_cacert"`
+	GatewayCert     types.String `tfsdk:"gateway_cert"`
+	GatewayInsecure types.Bool   `tfsdk:"gateway_insecure"`
+	GatewayKey      types.String `tfsdk:"gateway_key"`
+	GatewayPassword types.String `tfsdk:"gateway_password"`
+	GatewayUrl      types.String `tfsdk:"gateway_url"`
+	GatewayUser     types.String `tfsdk:"gateway_user"`
+	Insecure        types.Bool   `tfsdk:"insecure"`
+	Key             types.String `tfsdk:"key"`
 }

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -50,14 +50,64 @@
         {
           "name": "cert",
           "string": {
-            "description": "Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_CERT`. Must be used with key. If key is provided, cert is required. Useful when Console behind a reverse proxy with client certificate authentication.",
+            "description": "Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_CERT`. Must be used with key. If key is provided, cert is required. Useful when Console is behind a reverse proxy with client certificate authentication.",
             "optional_required": "optional"
           }
         },
         {
           "name": "key",
           "string": {
-            "description": "Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Console behind a reverse proxy with client certificate authentication.",
+            "description": "Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Console is behind a reverse proxy with client certificate authentication.",
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "gateway_url",
+          "string": {
+            "description": "The URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.",
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "gateway_user",
+          "string": {
+            "description": "The email of the Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.",
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "gateway_password",
+          "string": {
+            "description": "The password of Gateway the admin user. May be set using environment variable `CDK_GATEWAY_PASSWORD`. Required if gateway_url is set.",
+            "optional_required": "optional",
+            "sensitive": true
+          }
+        },
+        {
+          "name": "gateway_cacert",
+          "string": {
+            "description": "Root CA certificate in PEM format to verify the Conduktor Gateway certificate. May be set using environment variable `CDK_GATEWAY_CACERT`. If not provided, the system's root CA certificates will be used.",
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "gateway_insecure",
+          "bool": {
+            "description": "Skip TLS verification flag. May be set using environment variable `CDK_GATEWAY_INSECURE`.",
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "gateway_cert",
+          "string": {
+            "description": "Cert in PEM format to authenticate using client certificates. May be set using environment variable `CDK_GATEWAY_CERT`. Must be used with key. If key is provided, cert is required. Useful when Gateway is behind a reverse proxy with client certificate authentication.",
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "gateway_key",
+          "string": {
+            "description": "Key in PEM format to authenticate using client certificates. May be set using environment variable `CDK_GATEWAY_KEY`. Must be used with cert. If cert is provided, key is required. Useful when Gateway is behind a reverse proxy with client certificate authentication.",
             "optional_required": "optional"
           }
         }

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -64,14 +64,14 @@
         {
           "name": "gateway_url",
           "string": {
-            "description": "The URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.",
+            "description": "The administration URL of the Conduktor Gateway. May also be set using environment variable `CDK_GATEWAY_BASE_URL`. Required either here or in the environment.",
             "optional_required": "optional"
           }
         },
         {
           "name": "gateway_user",
           "string": {
-            "description": "The email of the Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.",
+            "description": "The login of a Gateway admin user. May be set using environment variable `CDK_GATEWAY_USER`. Required if gateway_url is set.",
             "optional_required": "optional"
           }
         },


### PR DESCRIPTION
Modification and changes:
 - `redpanda` and `conduktor-gateway` images added to `docker-compose` file.
 - Provider support for `Gateway` implementing a client with respective login parameters and certs.
 - Checks on each `Console` resource to throw an error if the Client hasn't been configured.
 - Minor reworks to avoid duplication.