### PR TITLE
Remove block for spec and replace with attribute single_nested instead

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-export SHELL:=/bin/bash
+export SHELL:=/bin/sh
 export SHELLOPTS:=$(if $(SHELLOPTS),$(SHELLOPTS):)pipefail:errexit
 
 include .env

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,9 +1,17 @@
-export SHELL:=/bin/sh
+export SHELL := /bin/sh
 export SHELLOPTS:=$(if $(SHELLOPTS),$(SHELLOPTS):)pipefail:errexit
 
-include .env
-
 .ONESHELL:
+
+# Include .env file
+include .env
+export $(shell sed 's/=.*//' .env)
+
+# Include .envrc file if it exists
+ifneq (,$(wildcard .envrc))
+  include .envrc
+  export $(shell grep -v '^#' .envrc | sed 's/export //')
+endif
 
 default: testacc
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -59,10 +59,7 @@ test: ## Run acceptance tests only (no setup or cleanup)
 # Run acceptance tests
 .PHONY: testacc
 testacc: start_test_env ## Start test environment, run acceptance tests and clean up
-	@function tearDown {
-		$(MAKE) clean
-	}
-	@trap tearDown EXIT
+	@trap '$(MAKE) clean' EXIT
 
 	$(MAKE) test
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ provider "conduktor" {
 # register an external user bob with PLATFORM.userView permission
 resource "conduktor_console_user_v2" "bob" {
   name = "bob@mycompany.io"
-  spec {
+  spec = {
     firstname = "Bob"
     lastname  = "Smith"
     permissions = [
@@ -124,7 +124,7 @@ resource "conduktor_console_user_v2" "bob" {
 # create a group with Bob as a member
 resource "conduktor_console_group_v2" "qa" {
   name = "qa"
-  spec {
+  spec = {
     display_name                 = "QA team"
     description                  = "Quality Assurance team"
     members                      = [ conduktor_user_v2.bob.name ]

--- a/docs/resources/console_group_v2.md
+++ b/docs/resources/console_group_v2.md
@@ -17,7 +17,7 @@ This resource allows you to create, read, update and delete groups in Conduktor.
 ```terraform
 resource "conduktor_console_group_v2" "example" {
   name = "simple-group"
-  spec {
+  spec = {
     display_name = "Simple Group"
     description  = "Simple group description"
   }
@@ -28,7 +28,7 @@ resource "conduktor_console_group_v2" "example" {
 ```terraform
 resource "conduktor_console_user_v2" "user1" {
   name = "user1@company.com"
-  spec {
+  spec = {
     firstname   = "User"
     lastname    = "1"
     permissions = []
@@ -37,7 +37,7 @@ resource "conduktor_console_user_v2" "user1" {
 
 resource "conduktor_console_group_v2" "example" {
   name = "complex-group"
-  spec {
+  spec = {
     display_name    = "Complex group"
     description     = "Complex group description"
     external_groups = ["sso-group1"]
@@ -66,12 +66,9 @@ resource "conduktor_console_group_v2" "example" {
 ### Required
 
 - `name` (String) Group name, must be unique, act as ID for import
+- `spec` (Attributes) Group specification (see [below for nested schema](#nestedatt--spec))
 
-### Optional
-
-- `spec` (Block, Optional) (see [below for nested schema](#nestedblock--spec))
-
-<a id="nestedblock--spec"></a>
+<a id="nestedatt--spec"></a>
 ### Nested Schema for `spec`
 
 Required:

--- a/docs/resources/console_kafka_cluster_v2.md
+++ b/docs/resources/console_kafka_cluster_v2.md
@@ -18,7 +18,7 @@ This example creates a simple Kafka cluster definition without authentication re
 ```terraform
 resource "conduktor_console_kafka_cluster_v2" "simple" {
   name = "simple-cluster"
-  spec {
+  spec = {
     display_name                 = "Simple kafka Cluster"
     icon                         = "kafka"
     color                        = "#000000"
@@ -37,7 +37,7 @@ resource "conduktor_console_kafka_cluster_v2" "confluent" {
   labels = {
     "env" = "staging"
   }
-  spec {
+  spec = {
     display_name      = "Confluent Cluster"
     bootstrap_servers = "aaa-aaaa.us-west4.gcp.confluent.cloud:9092"
     properties = {
@@ -89,7 +89,7 @@ resource "conduktor_console_kafka_cluster_v2" "aiven" {
   labels = {
     "env" = "test"
   }
-  spec {
+  spec = {
     display_name      = "Aiven Cluster"
     bootstrap_servers = "cluster.aiven.io:9092"
     properties = {
@@ -127,7 +127,7 @@ resource "conduktor_console_kafka_cluster_v2" "aws_msk" {
   labels = {
     "env" = "prod"
   }
-  spec {
+  spec = {
     display_name      = "AWS MSK Cluster"
     bootstrap_servers = "b-3-public.xxxxx.yyyyy.zz.kafka.eu-west-1.amazonaws.com:9198,b-2-public.xxxxx.yyyyy.zz.kafka.eu-west-1.amazonaws.com:9198,b-1-public.xxxxx.yyyyy.zz.kafka.eu-west-1.amazonaws.com:9198"
     properties = {
@@ -162,7 +162,7 @@ resource "conduktor_console_kafka_cluster_v2" "gateway" {
   labels = {
     "env" = "prod"
   }
-  spec {
+  spec = {
     display_name      = "Gateway Cluster"
     bootstrap_servers = "gateway:6969"
     properties = {
@@ -199,13 +199,13 @@ resource "conduktor_console_kafka_cluster_v2" "gateway" {
 ### Required
 
 - `name` (String) Kafka cluster name, must be unique, acts as an ID for import
+- `spec` (Attributes) Kafka cluster specification (see [below for nested schema](#nestedatt--spec))
 
 ### Optional
 
 - `labels` (Map of String) Kafka cluster labels
-- `spec` (Block, Optional) (see [below for nested schema](#nestedblock--spec))
 
-<a id="nestedblock--spec"></a>
+<a id="nestedatt--spec"></a>
 ### Nested Schema for `spec`
 
 Required:

--- a/docs/resources/console_kafka_connect_v2.md
+++ b/docs/resources/console_kafka_connect_v2.md
@@ -18,7 +18,7 @@ This example creates a simple Kafka Connect server connection without any authen
 ```terraform
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -27,7 +27,7 @@ resource "conduktor_console_kafka_cluster_v2" "minimal" {
 resource "conduktor_console_kafka_connect_v2" "simple" {
   name    = "simple-connect"
   cluster = conduktor_console_kafka_cluster_v2.minimal.name
-  spec {
+  spec = {
     display_name = "Simple Connect Server"
     urls         = "http://localhost:8083"
   }
@@ -39,7 +39,7 @@ This example creates a complex Kafka Connect server connection with basic authen
 ```terraform
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -53,7 +53,7 @@ resource "conduktor_console_kafka_connect_v2" "basic" {
     documentation = "https://docs.mycompany.com/complex-connect"
     env           = "dev"
   }
-  spec {
+  spec = {
     display_name = "Basic Connect server"
     urls         = "http://localhost:8083"
     headers = {
@@ -75,7 +75,7 @@ This example creates a complex Kafka Connect server connection with bearer token
 ```terraform
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -89,7 +89,7 @@ resource "conduktor_console_kafka_connect_v2" "bearer" {
     documentation = "https://docs.mycompany.com/complex-connect"
     env           = "dev"
   }
-  spec {
+  spec = {
     display_name = "Bearer Connect server"
     urls         = "http://localhost:8083"
     headers = {
@@ -110,7 +110,7 @@ This example creates a complex Kafka Connect server connection with mTLS authent
 ```terraform
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -124,7 +124,7 @@ resource "conduktor_console_kafka_connect_v2" "mtls" {
     documentation = "https://docs.mycompany.com/complex-connect"
     env           = "dev"
   }
-  spec {
+  spec = {
     display_name = "mTLS Connect server"
     urls         = "http://localhost:8083"
     headers = {
@@ -160,13 +160,13 @@ EOT
 
 - `cluster` (String) Kafka cluster name linked with Kafka current connect server. Must exist in Conduktor Console
 - `name` (String) Kafka connect server name, must be unique, act as ID for import
+- `spec` (Attributes) Kafka connect server specification (see [below for nested schema](#nestedatt--spec))
 
 ### Optional
 
 - `labels` (Map of String) Kafka connect server labels
-- `spec` (Block, Optional) (see [below for nested schema](#nestedblock--spec))
 
-<a id="nestedblock--spec"></a>
+<a id="nestedatt--spec"></a>
 ### Nested Schema for `spec`
 
 Required:

--- a/docs/resources/console_user_v2.md
+++ b/docs/resources/console_user_v2.md
@@ -17,7 +17,7 @@ This resource allows you to create, read, update and delete users in Conduktor.
 ```terraform
 resource "conduktor_console_user_v2" "example" {
   name = "bob@company.io"
-  spec {
+  spec = {
     firstname = "Bob"
     lastname  = "Smith"
   }
@@ -28,7 +28,7 @@ resource "conduktor_console_user_v2" "example" {
 ```terraform
 resource "conduktor_console_user_v2" "example" {
   name = "bob@company.io"
-  spec {
+  spec = {
     firstname = "Bob"
     lastname  = "Smith"
     permissions = [
@@ -55,12 +55,9 @@ resource "conduktor_console_user_v2" "example" {
 ### Required
 
 - `name` (String) User email, must be unique, act as ID for import
+- `spec` (Attributes) User specification (see [below for nested schema](#nestedatt--spec))
 
-### Optional
-
-- `spec` (Block, Optional) (see [below for nested schema](#nestedblock--spec))
-
-<a id="nestedblock--spec"></a>
+<a id="nestedatt--spec"></a>
 ### Nested Schema for `spec`
 
 Optional:

--- a/docs/resources/gateway_service_account_v2.md
+++ b/docs/resources/gateway_service_account_v2.md
@@ -18,7 +18,7 @@ This resource allows you to create, read, update and delete service accounts in 
 ```terraform
 resource "conduktor_gateway_service_account_v2" "local_sa" {
   name = "simple-service-account"
-  spec {
+  spec = {
     type = "LOCAL"
   }
 }
@@ -29,7 +29,7 @@ resource "conduktor_gateway_service_account_v2" "local_sa" {
 resource "conduktor_gateway_service_account_v2" "external_sa" {
   name     = "complex-service-account"
   vcluster = "vcluster_sa"
-  spec {
+  spec = {
     type           = "EXTERNAL"
     external_names = ["externalName"]
   }
@@ -43,13 +43,13 @@ resource "conduktor_gateway_service_account_v2" "external_sa" {
 ### Required
 
 - `name` (String) The name of the service account, must be unique, act as ID for import
+- `spec` (Attributes) Service account specification (see [below for nested schema](#nestedatt--spec))
 
 ### Optional
 
-- `spec` (Block, Optional) (see [below for nested schema](#nestedblock--spec))
 - `vcluster` (String) The name of the virtual cluster the service account belongs to. If not provided, the service account will be created in the default passthrough virtual cluster.
 
-<a id="nestedblock--spec"></a>
+<a id="nestedatt--spec"></a>
 ### Nested Schema for `spec`
 
 Required:

--- a/examples/resources/conduktor_console_group_v2/complex.tf
+++ b/examples/resources/conduktor_console_group_v2/complex.tf
@@ -1,6 +1,6 @@
 resource "conduktor_console_user_v2" "user1" {
   name = "user1@company.com"
-  spec {
+  spec = {
     firstname   = "User"
     lastname    = "1"
     permissions = []
@@ -9,7 +9,7 @@ resource "conduktor_console_user_v2" "user1" {
 
 resource "conduktor_console_group_v2" "example" {
   name = "complex-group"
-  spec {
+  spec = {
     display_name    = "Complex group"
     description     = "Complex group description"
     external_groups = ["sso-group1"]

--- a/examples/resources/conduktor_console_group_v2/simple.tf
+++ b/examples/resources/conduktor_console_group_v2/simple.tf
@@ -1,6 +1,6 @@
 resource "conduktor_console_group_v2" "example" {
   name = "simple-group"
-  spec {
+  spec = {
     display_name = "Simple Group"
     description  = "Simple group description"
   }

--- a/examples/resources/conduktor_console_kafka_cluster_v2/aiven.tf
+++ b/examples/resources/conduktor_console_kafka_cluster_v2/aiven.tf
@@ -3,7 +3,7 @@ resource "conduktor_console_kafka_cluster_v2" "aiven" {
   labels = {
     "env" = "test"
   }
-  spec {
+  spec = {
     display_name      = "Aiven Cluster"
     bootstrap_servers = "cluster.aiven.io:9092"
     properties = {

--- a/examples/resources/conduktor_console_kafka_cluster_v2/aws_msk.tf
+++ b/examples/resources/conduktor_console_kafka_cluster_v2/aws_msk.tf
@@ -3,7 +3,7 @@ resource "conduktor_console_kafka_cluster_v2" "aws_msk" {
   labels = {
     "env" = "prod"
   }
-  spec {
+  spec = {
     display_name      = "AWS MSK Cluster"
     bootstrap_servers = "b-3-public.xxxxx.yyyyy.zz.kafka.eu-west-1.amazonaws.com:9198,b-2-public.xxxxx.yyyyy.zz.kafka.eu-west-1.amazonaws.com:9198,b-1-public.xxxxx.yyyyy.zz.kafka.eu-west-1.amazonaws.com:9198"
     properties = {

--- a/examples/resources/conduktor_console_kafka_cluster_v2/confluent.tf
+++ b/examples/resources/conduktor_console_kafka_cluster_v2/confluent.tf
@@ -3,7 +3,7 @@ resource "conduktor_console_kafka_cluster_v2" "confluent" {
   labels = {
     "env" = "staging"
   }
-  spec {
+  spec = {
     display_name      = "Confluent Cluster"
     bootstrap_servers = "aaa-aaaa.us-west4.gcp.confluent.cloud:9092"
     properties = {

--- a/examples/resources/conduktor_console_kafka_cluster_v2/gateway.tf
+++ b/examples/resources/conduktor_console_kafka_cluster_v2/gateway.tf
@@ -3,7 +3,7 @@ resource "conduktor_console_kafka_cluster_v2" "gateway" {
   labels = {
     "env" = "prod"
   }
-  spec {
+  spec = {
     display_name      = "Gateway Cluster"
     bootstrap_servers = "gateway:6969"
     properties = {

--- a/examples/resources/conduktor_console_kafka_cluster_v2/simple.tf
+++ b/examples/resources/conduktor_console_kafka_cluster_v2/simple.tf
@@ -1,6 +1,6 @@
 resource "conduktor_console_kafka_cluster_v2" "simple" {
   name = "simple-cluster"
-  spec {
+  spec = {
     display_name                 = "Simple kafka Cluster"
     icon                         = "kafka"
     color                        = "#000000"

--- a/examples/resources/conduktor_console_kafka_connect_v2/basicAuth.tf
+++ b/examples/resources/conduktor_console_kafka_connect_v2/basicAuth.tf
@@ -1,6 +1,6 @@
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -14,7 +14,7 @@ resource "conduktor_console_kafka_connect_v2" "basic" {
     documentation = "https://docs.mycompany.com/complex-connect"
     env           = "dev"
   }
-  spec {
+  spec = {
     display_name = "Basic Connect server"
     urls         = "http://localhost:8083"
     headers = {

--- a/examples/resources/conduktor_console_kafka_connect_v2/bearerToken.tf
+++ b/examples/resources/conduktor_console_kafka_connect_v2/bearerToken.tf
@@ -1,6 +1,6 @@
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -14,7 +14,7 @@ resource "conduktor_console_kafka_connect_v2" "bearer" {
     documentation = "https://docs.mycompany.com/complex-connect"
     env           = "dev"
   }
-  spec {
+  spec = {
     display_name = "Bearer Connect server"
     urls         = "http://localhost:8083"
     headers = {

--- a/examples/resources/conduktor_console_kafka_connect_v2/mtls.tf
+++ b/examples/resources/conduktor_console_kafka_connect_v2/mtls.tf
@@ -1,6 +1,6 @@
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -14,7 +14,7 @@ resource "conduktor_console_kafka_connect_v2" "mtls" {
     documentation = "https://docs.mycompany.com/complex-connect"
     env           = "dev"
   }
-  spec {
+  spec = {
     display_name = "mTLS Connect server"
     urls         = "http://localhost:8083"
     headers = {

--- a/examples/resources/conduktor_console_kafka_connect_v2/simple.tf
+++ b/examples/resources/conduktor_console_kafka_connect_v2/simple.tf
@@ -1,6 +1,6 @@
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -9,7 +9,7 @@ resource "conduktor_console_kafka_cluster_v2" "minimal" {
 resource "conduktor_console_kafka_connect_v2" "simple" {
   name    = "simple-connect"
   cluster = conduktor_console_kafka_cluster_v2.minimal.name
-  spec {
+  spec = {
     display_name = "Simple Connect Server"
     urls         = "http://localhost:8083"
   }

--- a/examples/resources/conduktor_console_user_v2/complex.tf
+++ b/examples/resources/conduktor_console_user_v2/complex.tf
@@ -1,6 +1,6 @@
 resource "conduktor_console_user_v2" "example" {
   name = "bob@company.io"
-  spec {
+  spec = {
     firstname = "Bob"
     lastname  = "Smith"
     permissions = [

--- a/examples/resources/conduktor_console_user_v2/simple.tf
+++ b/examples/resources/conduktor_console_user_v2/simple.tf
@@ -1,6 +1,6 @@
 resource "conduktor_console_user_v2" "example" {
   name = "bob@company.io"
-  spec {
+  spec = {
     firstname = "Bob"
     lastname  = "Smith"
   }

--- a/examples/resources/conduktor_gateway_service_account_v2/complex.tf
+++ b/examples/resources/conduktor_gateway_service_account_v2/complex.tf
@@ -1,7 +1,7 @@
 resource "conduktor_gateway_service_account_v2" "external_sa" {
   name     = "complex-service-account"
   vcluster = "vcluster_sa"
-  spec {
+  spec = {
     type           = "EXTERNAL"
     external_names = ["externalName"]
   }

--- a/examples/resources/conduktor_gateway_service_account_v2/simple.tf
+++ b/examples/resources/conduktor_gateway_service_account_v2/simple.tf
@@ -1,6 +1,6 @@
 resource "conduktor_gateway_service_account_v2" "local_sa" {
   name = "simple-service-account"
-  spec {
+  spec = {
     type = "LOCAL"
   }
 }

--- a/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
+++ b/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
@@ -37,9 +37,7 @@ func ConsoleGroupV2ResourceSchema(ctx context.Context) schema.Schema {
 					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
 				},
 			},
-		},
-		Blocks: map[string]schema.Block{
-			"spec": schema.SingleNestedBlock{
+			"spec": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"description": schema.StringAttribute{
 						Optional:            true,
@@ -135,6 +133,9 @@ func ConsoleGroupV2ResourceSchema(ctx context.Context) schema.Schema {
 						AttrTypes: SpecValue{}.AttributeTypes(ctx),
 					},
 				},
+				Required:            true,
+				Description:         "Group specification",
+				MarkdownDescription: "Group specification",
 			},
 		},
 	}

--- a/internal/schema/resource_console_kafka_cluster_v2/console_kafka_cluster_v2_resource_gen.go
+++ b/internal/schema/resource_console_kafka_cluster_v2/console_kafka_cluster_v2_resource_gen.go
@@ -44,9 +44,7 @@ func ConsoleKafkaClusterV2ResourceSchema(ctx context.Context) schema.Schema {
 					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
-		},
-		Blocks: map[string]schema.Block{
-			"spec": schema.SingleNestedBlock{
+			"spec": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"bootstrap_servers": schema.StringAttribute{
 						Required:            true,
@@ -322,6 +320,9 @@ func ConsoleKafkaClusterV2ResourceSchema(ctx context.Context) schema.Schema {
 						AttrTypes: SpecValue{}.AttributeTypes(ctx),
 					},
 				},
+				Required:            true,
+				Description:         "Kafka cluster specification",
+				MarkdownDescription: "Kafka cluster specification",
 			},
 		},
 	}

--- a/internal/schema/resource_console_kafka_connect_v2/console_kafka_connect_v2_resource_gen.go
+++ b/internal/schema/resource_console_kafka_connect_v2/console_kafka_connect_v2_resource_gen.go
@@ -54,9 +54,7 @@ func ConsoleKafkaConnectV2ResourceSchema(ctx context.Context) schema.Schema {
 					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
-		},
-		Blocks: map[string]schema.Block{
-			"spec": schema.SingleNestedBlock{
+			"spec": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"display_name": schema.StringAttribute{
 						Required:            true,
@@ -135,6 +133,9 @@ func ConsoleKafkaConnectV2ResourceSchema(ctx context.Context) schema.Schema {
 						AttrTypes: SpecValue{}.AttributeTypes(ctx),
 					},
 				},
+				Required:            true,
+				Description:         "Kafka connect server specification",
+				MarkdownDescription: "Kafka connect server specification",
 			},
 		},
 	}

--- a/internal/schema/resource_console_user_v2/console_user_v2_resource_gen.go
+++ b/internal/schema/resource_console_user_v2/console_user_v2_resource_gen.go
@@ -36,9 +36,7 @@ func ConsoleUserV2ResourceSchema(ctx context.Context) schema.Schema {
 					stringvalidator.RegexMatches(regexp.MustCompile("^([\\w\\-_.]*[^.])@([\\w-]+\\.)+[\\w-]{2,4}$"), ""),
 				},
 			},
-		},
-		Blocks: map[string]schema.Block{
-			"spec": schema.SingleNestedBlock{
+			"spec": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"firstname": schema.StringAttribute{
 						Optional:            true,
@@ -111,6 +109,9 @@ func ConsoleUserV2ResourceSchema(ctx context.Context) schema.Schema {
 						AttrTypes: SpecValue{}.AttributeTypes(ctx),
 					},
 				},
+				Required:            true,
+				Description:         "User specification",
+				MarkdownDescription: "User specification",
 			},
 		},
 	}

--- a/internal/schema/resource_gateway_service_account_v2/gateway_service_account_v2_resource_gen.go
+++ b/internal/schema/resource_gateway_service_account_v2/gateway_service_account_v2_resource_gen.go
@@ -38,22 +38,7 @@ func GatewayServiceAccountV2ResourceSchema(ctx context.Context) schema.Schema {
 					stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9_-]{3,64}$"), ""),
 				},
 			},
-			"vcluster": schema.StringAttribute{
-				Optional:            true,
-				Computed:            true,
-				Description:         "The name of the virtual cluster the service account belongs to. If not provided, the service account will be created in the default passthrough virtual cluster.",
-				MarkdownDescription: "The name of the virtual cluster the service account belongs to. If not provided, the service account will be created in the default passthrough virtual cluster.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9_-]+$"), ""),
-				},
-				Default: stringdefault.StaticString("passthrough"),
-			},
-		},
-		Blocks: map[string]schema.Block{
-			"spec": schema.SingleNestedBlock{
+			"spec": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"external_names": schema.SetAttribute{
 						ElementType:         types.StringType,
@@ -80,6 +65,22 @@ func GatewayServiceAccountV2ResourceSchema(ctx context.Context) schema.Schema {
 						AttrTypes: SpecValue{}.AttributeTypes(ctx),
 					},
 				},
+				Required:            true,
+				Description:         "Service account specification",
+				MarkdownDescription: "Service account specification",
+			},
+			"vcluster": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "The name of the virtual cluster the service account belongs to. If not provided, the service account will be created in the default passthrough virtual cluster.",
+				MarkdownDescription: "The name of the virtual cluster the service account belongs to. If not provided, the service account will be created in the default passthrough virtual cluster.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9_-]+$"), ""),
+				},
+				Default: stringdefault.StaticString("passthrough"),
 			},
 		},
 	}
@@ -87,8 +88,8 @@ func GatewayServiceAccountV2ResourceSchema(ctx context.Context) schema.Schema {
 
 type GatewayServiceAccountV2Model struct {
 	Name     types.String `tfsdk:"name"`
-	Vcluster types.String `tfsdk:"vcluster"`
 	Spec     SpecValue    `tfsdk:"spec"`
+	Vcluster types.String `tfsdk:"vcluster"`
 }
 
 var _ basetypes.ObjectTypable = SpecType{}

--- a/internal/testdata/console_group_v2_resource_create.tf
+++ b/internal/testdata/console_group_v2_resource_create.tf
@@ -1,7 +1,7 @@
 
 resource "conduktor_console_group_v2" "test" {
   name = "sales"
-  spec {
+  spec = {
     display_name    = "Sales Department"
     description     = "Sales Department Group"
     external_groups = ["sales"]

--- a/internal/testdata/console_group_v2_resource_minimal.tf
+++ b/internal/testdata/console_group_v2_resource_minimal.tf
@@ -1,7 +1,7 @@
 
 resource "conduktor_console_group_v2" "minimal" {
   name = "minimal"
-  spec {
+  spec = {
     display_name    = "Minimal"
   }
 }

--- a/internal/testdata/console_group_v2_resource_update.tf
+++ b/internal/testdata/console_group_v2_resource_update.tf
@@ -1,7 +1,7 @@
 
 resource "conduktor_console_user_v2" "coworkers1" {
   name = "michael.scott@dunder.mifflin.com"
-  spec {
+  spec = {
     firstname   = "Michael"
     lastname    = "Scott"
     permissions = []
@@ -10,7 +10,7 @@ resource "conduktor_console_user_v2" "coworkers1" {
 
 resource "conduktor_console_group_v2" "test" {
   name = "sales"
-  spec {
+  spec = {
     display_name    = "New Sales Department"
     description     = "New Sales Department Group"
     external_groups = ["sales", "scranton"]

--- a/internal/testdata/console_kafka_cluster_v2_resource_create.tf
+++ b/internal/testdata/console_kafka_cluster_v2_resource_create.tf
@@ -4,7 +4,7 @@ resource "conduktor_console_kafka_cluster_v2" "test" {
   labels = {
     "env" = "test"
   }
-  spec {
+  spec = {
     display_name      = "Test Cluster"
     bootstrap_servers = "localhost:9092"
     properties         = {

--- a/internal/testdata/console_kafka_cluster_v2_resource_minimal.tf
+++ b/internal/testdata/console_kafka_cluster_v2_resource_minimal.tf
@@ -1,7 +1,7 @@
 
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }

--- a/internal/testdata/console_kafka_cluster_v2_resource_update.tf
+++ b/internal/testdata/console_kafka_cluster_v2_resource_update.tf
@@ -5,7 +5,7 @@ resource "conduktor_console_kafka_cluster_v2" "test" {
     "env" = "test"
     "sec" = "C1"
   }
-  spec {
+  spec = {
     display_name      = "Test Cluster"
     bootstrap_servers = "cluster.aiven.io:9092"
     properties         = {

--- a/internal/testdata/console_kafka_connect_v2_resource_create.tf
+++ b/internal/testdata/console_kafka_connect_v2_resource_create.tf
@@ -1,7 +1,7 @@
 
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -13,7 +13,7 @@ resource "conduktor_console_kafka_connect_v2" "test" {
   labels = {
     env = "test"
   }
-  spec {
+  spec = {
     display_name      = "Test Connect"
     urls = "http://localhost:8083"
     headers         = {

--- a/internal/testdata/console_kafka_connect_v2_resource_minimal.tf
+++ b/internal/testdata/console_kafka_connect_v2_resource_minimal.tf
@@ -1,7 +1,7 @@
 
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -10,7 +10,7 @@ resource "conduktor_console_kafka_cluster_v2" "minimal" {
 resource "conduktor_console_kafka_connect_v2" "minimal" {
   name = "minimal-connect"
   cluster = conduktor_console_kafka_cluster_v2.minimal.name
-  spec {
+  spec = {
     display_name = "Minimal Connect"
     urls         = "http://localhost:8083"
   }

--- a/internal/testdata/console_kafka_connect_v2_resource_update.tf
+++ b/internal/testdata/console_kafka_connect_v2_resource_update.tf
@@ -1,7 +1,7 @@
 
 resource "conduktor_console_kafka_cluster_v2" "minimal" {
   name = "mini-cluster"
-  spec {
+  spec = {
     display_name      = "Minimal Cluster"
     bootstrap_servers = "localhost:9092"
   }
@@ -14,7 +14,7 @@ resource "conduktor_console_kafka_connect_v2" "test" {
     env = "test"
     security = "C1"
   }
-  spec {
+  spec = {
     display_name      = "Test Connect updated"
     urls = "http://localhost:8083"
     headers         = {

--- a/internal/testdata/console_user_v2_resource_create.tf
+++ b/internal/testdata/console_user_v2_resource_create.tf
@@ -1,7 +1,7 @@
 
 resource "conduktor_console_user_v2" "test" {
   name = "pam.beesly@dunder.mifflin.com"
-  spec {
+  spec = {
     firstname = "Pam"
     lastname  = "Beesly"
     permissions = [

--- a/internal/testdata/console_user_v2_resource_minimal.tf
+++ b/internal/testdata/console_user_v2_resource_minimal.tf
@@ -1,6 +1,6 @@
 
 resource "conduktor_console_user_v2" "minimal" {
   name = "angela.martin@dunder-mifflin.com"
-  spec {
+  spec = {
   }
 }

--- a/internal/testdata/console_user_v2_resource_update.tf
+++ b/internal/testdata/console_user_v2_resource_update.tf
@@ -1,7 +1,7 @@
 
 resource "conduktor_console_user_v2" "test" {
   name = "pam.beesly@dunder.mifflin.com"
-  spec {
+  spec = {
     firstname = "Pam"
     lastname  = "Halpert"
     permissions = [

--- a/internal/testdata/gateway_service_account_v2_resource_create.tf
+++ b/internal/testdata/gateway_service_account_v2_resource_create.tf
@@ -2,7 +2,7 @@
 resource "conduktor_gateway_service_account_v2" "test" {
   name     = "user1"
   vcluster = "vcluster_sa"
-  spec {
+  spec = {
     type           = "EXTERNAL"
     external_names = ["externalName"]
   }

--- a/internal/testdata/gateway_service_account_v2_resource_minimal.tf
+++ b/internal/testdata/gateway_service_account_v2_resource_minimal.tf
@@ -1,7 +1,7 @@
 
 resource "conduktor_gateway_service_account_v2" "minimal" {
   name = "minimal"
-  spec {
+  spec = {
     type = "LOCAL"
   }
 }

--- a/internal/testdata/gateway_service_account_v2_resource_update.tf
+++ b/internal/testdata/gateway_service_account_v2_resource_update.tf
@@ -2,7 +2,7 @@
 resource "conduktor_gateway_service_account_v2" "test" {
   name     = "user1"
   vcluster = "vcluster_sa"
-  spec {
+  spec = {
     type           = "EXTERNAL"
     external_names = ["newExternalName"]
   }

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -125,12 +125,12 @@
                 }
               ]
             }
-          }
-        ],
-        "blocks": [
+          },
           {
             "name": "spec",
             "single_nested": {
+              "computed_optional_required": "required",
+              "description": "Group specification",
               "attributes": [
                 {
                   "name": "display_name",
@@ -365,12 +365,12 @@
                 "string": {}
               }
             }
-          }
-        ],
-        "blocks": [
+          },
           {
             "name": "spec",
             "single_nested": {
+              "computed_optional_required": "required",
+              "description": "Kafka cluster specification",
               "attributes": [
                 {
                   "name": "display_name",
@@ -875,12 +875,12 @@
                 "string": {}
               }
             }
-          }
-        ],
-        "blocks": [
+          },
           {
             "name": "spec",
             "single_nested": {
+              "computed_optional_required": "required",
+              "description": "Kafka connect server specification",
               "attributes": [
                 {
                   "name": "display_name",
@@ -1035,12 +1035,12 @@
                 }
               ]
             }
-          }
-        ],
-        "blocks": [
+          },
           {
             "name": "spec",
             "single_nested": {
+              "computed_optional_required": "required",
+              "description": "User specification",
               "attributes": [
                 {
                   "name": "firstname",
@@ -1247,12 +1247,12 @@
                 }
               ]
             }
-          }
-        ],
-        "blocks": [
+          },
           {
             "name": "spec",
             "single_nested": {
+              "computed_optional_required": "required",
+              "description": "Service account specification",
               "attributes": [
                 {
                   "name": "type",


### PR DESCRIPTION
BREAKING CHANGE : 

Replace deprecated [blocks](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/blocks) for `spec` in resources schema with simple attribute single_nested.

Changes on all resources : 

```hcl
resource "xxx" "yyy" {
  name = "zzz"
  spec {  # <= previously
   ...
  }
}
``` 

```hcl
resource "xxx" "yyy" {
  name = "zzz"
  spec = {  # <= Now
   ...
  }
}
``` 