### PR TITLE
Fix conduktor_generic resource examples tests

### DIFF
--- a/docs/resources/generic.md
+++ b/docs/resources/generic.md
@@ -22,15 +22,15 @@ This resource allows you to create, read, update and delete any resource support
 resource "conduktor_generic" "embedded" {
   kind    = "User"
   version = "v2"
-  name    = "bob@company.io"
+  name    = "martin@company.io"
   manifest = yamlencode({
     apiVersion = "v2"
     kind       = "User"
     metadata = {
-      name = "bob@company.io"
+      name = "martin@company.io"
     }
     spec = {
-      firstName = "Bob"
+      firstName = "Martin"
       lastName  = "Smith"
       permissions = [
         {
@@ -63,15 +63,15 @@ resource "conduktor_generic" "embedded" {
 resource "conduktor_generic" "raw_yaml" {
   kind    = "User"
   version = "v2"
-  name    = "bob@company.io"
+  name    = "alice@company.io"
   manifest = yamlencode(yamldecode(<<EOF
       apiVersion: v2
       kind: User
       metadata:
-        name: "bob@company.io"
+        name: "alice@company.io"
       spec:
-        firstName: "Bob"
-        lastName: Smith
+        firstName: "Alice"
+        lastName: "Smith"
         permissions:
           - resourceType: PLATFORM
             permissions: ["userView", "datamaskingView", "auditLogView"]

--- a/examples/resources/conduktor_generic/embedded.tf
+++ b/examples/resources/conduktor_generic/embedded.tf
@@ -1,15 +1,15 @@
 resource "conduktor_generic" "embedded" {
   kind    = "User"
   version = "v2"
-  name    = "bob@company.io"
+  name    = "martin@company.io"
   manifest = yamlencode({
     apiVersion = "v2"
     kind       = "User"
     metadata = {
-      name = "bob@company.io"
+      name = "martin@company.io"
     }
     spec = {
-      firstName = "Bob"
+      firstName = "Martin"
       lastName  = "Smith"
       permissions = [
         {

--- a/examples/resources/conduktor_generic/raw_yaml.tf
+++ b/examples/resources/conduktor_generic/raw_yaml.tf
@@ -1,15 +1,15 @@
 resource "conduktor_generic" "raw_yaml" {
   kind    = "User"
   version = "v2"
-  name    = "bob@company.io"
+  name    = "alice@company.io"
   manifest = yamlencode(yamldecode(<<EOF
       apiVersion: v2
       kind: User
       metadata:
-        name: "bob@company.io"
+        name: "alice@company.io"
       spec:
-        firstName: "Bob"
-        lastName: Smith
+        firstName: "Alice"
+        lastName: "Smith"
         permissions:
           - resourceType: PLATFORM
             permissions: ["userView", "datamaskingView", "auditLogView"]

--- a/internal/provider/generic_resource_test.go
+++ b/internal/provider/generic_resource_test.go
@@ -52,28 +52,27 @@ func TestAccGenericExample2Resource(t *testing.T) {
 			{
 				Config: providerConfigConsole + test.TestAccExample(t, "resources", "conduktor_generic", "embedded.tf"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("conduktor_generic.embedded", "name", "bob@company.io"),
+					resource.TestCheckResourceAttr("conduktor_generic.embedded", "name", "martin@company.io"),
 					resource.TestCheckResourceAttrWith("conduktor_generic.embedded", "manifest",
 						test.TestCheckResourceAttrContainsStringsFunc(
-							"\"name\": \"bob@company.io\"",
-							"\"firstName\": \"Bob\"",
+							"\"name\": \"martin@company.io\"",
+							"\"firstName\": \"Martin\"",
 							"\"lastName\": \"Smith\"",
 						)),
 				),
 			},
-			// Commenting out for now as it makes tests fail
-			// {
-			// 	Config: providerConfigConsole + test.TestAccExample(t, "resources", "conduktor_generic", "raw_yaml.tf"),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("conduktor_generic.raw_yaml", "name", "bob@company.io"),
-			// 		resource.TestCheckResourceAttrWith("conduktor_generic.raw_yaml", "manifest",
-			// 			test.TestCheckResourceAttrContainsStringsFunc(
-			// 				"\"name\": \"bob@company.io\"",
-			// 				"\"firstName\": \"Bob\"",
-			// 				"\"lastName\": \"Smith\"",
-			// 			)),
-			// 	),
-			// },
+			{
+				Config: providerConfigConsole + test.TestAccExample(t, "resources", "conduktor_generic", "raw_yaml.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("conduktor_generic.raw_yaml", "name", "alice@company.io"),
+					resource.TestCheckResourceAttrWith("conduktor_generic.raw_yaml", "manifest",
+						test.TestCheckResourceAttrContainsStringsFunc(
+							"\"name\": \"alice@company.io\"",
+							"\"firstName\": \"Alice\"",
+							"\"lastName\": \"Smith\"",
+						)),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
Avoid resource collision by using different user email identifier for each test.