### PR TITLE
Fixed issue where externally mapped users would show up when planning and applying resources

### DIFF
--- a/docs/resources/console_group_v2.md
+++ b/docs/resources/console_group_v2.md
@@ -84,7 +84,7 @@ Optional:
 
 Read-Only:
 
-- `members_from_external_groups` (Set of String) Set of members of the group (managed by backend, not tracked by Terraform)
+- `members_from_external_groups` (Set of String) Set of members of the group (managed by backend, ReadOnly in Terraform
 
 <a id="nestedatt--spec--permissions"></a>
 ### Nested Schema for `spec.permissions`

--- a/docs/resources/console_group_v2.md
+++ b/docs/resources/console_group_v2.md
@@ -84,7 +84,7 @@ Optional:
 
 Read-Only:
 
-- `members_from_external_groups` (Set of String) Set of members of the group
+- `members_from_external_groups` (Set of String) Set of members of the group (managed by backend, not tracked by Terraform)
 
 <a id="nestedatt--spec--permissions"></a>
 ### Nested Schema for `spec.permissions`

--- a/internal/planmodifiers/always_use_state.go
+++ b/internal/planmodifiers/always_use_state.go
@@ -1,0 +1,37 @@
+package planmodifiers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// AlwaysUseStateForSet returns a plan modifier that always uses the state value for a set attribute.
+// This effectively ignores any changes to the attribute during planning.
+func AlwaysUseStateForSet() planmodifier.Set {
+	return &alwaysUseStateForSetModifier{}
+}
+
+// alwaysUseStateForSetModifier implements the plan modifier.
+type alwaysUseStateForSetModifier struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m *alwaysUseStateForSetModifier) Description(ctx context.Context) string {
+	return "Always uses the state value for this attribute, ignoring any changes."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m *alwaysUseStateForSetModifier) MarkdownDescription(ctx context.Context) string {
+	return "Always uses the state value for this attribute, ignoring any changes."
+}
+
+// PlanModifySet implements the plan modification logic.
+func (m *alwaysUseStateForSetModifier) PlanModifySet(ctx context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	// If there's no state value, don't modify the plan
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Always use the state value, ignoring any changes
+	resp.PlanValue = req.StateValue
+}

--- a/internal/planmodifiers/always_use_state.go
+++ b/internal/planmodifiers/always_use_state.go
@@ -6,14 +6,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
+// alwaysUseStateForSetModifier implements the plan modifier.
+type alwaysUseStateForSetModifier struct{}
+
 // AlwaysUseStateForSet returns a plan modifier that always uses the state value for a set attribute.
 // This effectively ignores any changes to the attribute during planning.
 func AlwaysUseStateForSet() planmodifier.Set {
 	return &alwaysUseStateForSetModifier{}
 }
-
-// alwaysUseStateForSetModifier implements the plan modifier.
-type alwaysUseStateForSetModifier struct{}
 
 // Description returns a human-readable description of the plan modifier.
 func (m *alwaysUseStateForSetModifier) Description(ctx context.Context) string {

--- a/internal/provider/console_group_v2_resource.go
+++ b/internal/provider/console_group_v2_resource.go
@@ -144,10 +144,19 @@ func (r *GroupV2Resource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 	tflog.Debug(ctx, fmt.Sprintf("New group state : %+v", consoleRes))
 
+	// Store the current value of members_from_external_groups
+	currentMembersFromExternalGroups := data.Spec.MembersFromExternalGroups
+
 	data, err = mapper.InternalModelToTerraform(ctx, &consoleRes)
 	if err != nil {
 		resp.Diagnostics.AddError("Model Error", fmt.Sprintf("Unable to read group, got error: %s", err))
 		return
+	}
+
+	// Use the current value for members_from_external_groups to prevent unnecessary state changes
+	// Only use the backend value if this is the first read (currentMembersFromExternalGroups is empty)
+	if !currentMembersFromExternalGroups.IsNull() && !currentMembersFromExternalGroups.IsUnknown() {
+		data.Spec.MembersFromExternalGroups = currentMembersFromExternalGroups
 	}
 
 	// Save updated data into Terraform state
@@ -156,13 +165,21 @@ func (r *GroupV2Resource) Read(ctx context.Context, req resource.ReadRequest, re
 
 func (r *GroupV2Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data schema.ConsoleGroupV2Model
+	var state schema.ConsoleGroupV2Model
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
+	// Read the current state to get the current value of members_from_external_groups
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Use the state value for members_from_external_groups instead of the plan value
+	// This effectively ignores any changes to this field during planning
+	data.Spec.MembersFromExternalGroups = state.Spec.MembersFromExternalGroups
 
 	tflog.Info(ctx, fmt.Sprintf("Updating group named %s", data.Name.String()))
 	tflog.Trace(ctx, fmt.Sprintf("Update group with TF data: %+v", data))

--- a/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
+++ b/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -73,7 +72,6 @@ func ConsoleGroupV2ResourceSchema(ctx context.Context) schema.Schema {
 						Description:         "Set of members of the group (managed by backend, not tracked by Terraform)",
 						MarkdownDescription: "Set of members of the group (managed by backend, not tracked by Terraform)",
 						PlanModifiers: []planmodifier.Set{
-							setplanmodifier.UseStateForUnknown(),
 							planmodifiers.AlwaysUseStateForSet(),
 						},
 						Default: setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{})),

--- a/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
+++ b/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
@@ -5,6 +5,7 @@ package resource_console_group_v2
 import (
 	"context"
 	"fmt"
+	"github.com/conduktor/terraform-provider-conduktor/internal/planmodifiers"
 	"github.com/conduktor/terraform-provider-conduktor/internal/schema/validation"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -73,6 +74,7 @@ func ConsoleGroupV2ResourceSchema(ctx context.Context) schema.Schema {
 						MarkdownDescription: "Set of members of the group (managed by backend, not tracked by Terraform)",
 						PlanModifiers: []planmodifier.Set{
 							setplanmodifier.UseStateForUnknown(),
+							planmodifiers.AlwaysUseStateForSet(),
 						},
 						Default: setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{})),
 					},

--- a/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
+++ b/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
@@ -69,8 +69,8 @@ func ConsoleGroupV2ResourceSchema(ctx context.Context) schema.Schema {
 					"members_from_external_groups": schema.SetAttribute{
 						ElementType:         types.StringType,
 						Computed:            true,
-						Description:         "Set of members of the group (managed by backend, not tracked by Terraform)",
-						MarkdownDescription: "Set of members of the group (managed by backend, not tracked by Terraform)",
+						Description:         "Set of members of the group (managed by backend, ReadOnly in Terraform",
+						MarkdownDescription: "Set of members of the group (managed by backend, ReadOnly in Terraform",
 						PlanModifiers: []planmodifier.Set{
 							planmodifiers.AlwaysUseStateForSet(),
 						},

--- a/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
+++ b/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -68,9 +69,12 @@ func ConsoleGroupV2ResourceSchema(ctx context.Context) schema.Schema {
 					"members_from_external_groups": schema.SetAttribute{
 						ElementType:         types.StringType,
 						Computed:            true,
-						Description:         "Set of members of the group",
-						MarkdownDescription: "Set of members of the group",
-						Default:             setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{})),
+						Description:         "Set of members of the group (managed by backend, not tracked by Terraform)",
+						MarkdownDescription: "Set of members of the group (managed by backend, not tracked by Terraform)",
+						PlanModifiers: []planmodifier.Set{
+							setplanmodifier.UseStateForUnknown(),
+						},
+						Default: setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{})),
 					},
 					"permissions": schema.SetNestedAttribute{
 						NestedObject: schema.NestedAttributeObject{

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -510,16 +510,6 @@
                         "custom": {
                           "imports": [
                             {
-                              "path": "github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
-                            }
-                          ],
-                          "schema_definition": "setplanmodifier.UseStateForUnknown()"
-                        }
-                      },
-                      {
-                        "custom": {
-                          "imports": [
-                            {
                               "path": "github.com/conduktor/terraform-provider-conduktor/internal/planmodifiers"
                             }
                           ],

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -489,7 +489,7 @@
                 {
                   "name": "members_from_external_groups",
                   "set": {
-                    "description": "Set of members of the group",
+                    "description": "Set of members of the group (managed by backend, not tracked by Terraform)",
                     "computed_optional_required": "computed",
                     "element_type": {
                       "string": {}
@@ -504,7 +504,19 @@
                         "schema_definition": "setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{}))"
                       }
                     },
-                    "validators": []
+                    "validators": [],
+                    "plan_modifiers": [
+                      {
+                        "custom": {
+                          "imports": [
+                            {
+                              "path": "github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+                            }
+                          ],
+                          "schema_definition": "setplanmodifier.UseStateForUnknown()"
+                        }
+                      }
+                    ]
                   }
                 },
                 {

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -515,6 +515,16 @@
                           ],
                           "schema_definition": "setplanmodifier.UseStateForUnknown()"
                         }
+                      },
+                      {
+                        "custom": {
+                          "imports": [
+                            {
+                              "path": "github.com/conduktor/terraform-provider-conduktor/internal/planmodifiers"
+                            }
+                          ],
+                          "schema_definition": "planmodifiers.AlwaysUseStateForSet()"
+                        }
                       }
                     ]
                   }

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -489,7 +489,7 @@
                 {
                   "name": "members_from_external_groups",
                   "set": {
-                    "description": "Set of members of the group (managed by backend, not tracked by Terraform)",
+                    "description": "Set of members of the group (managed by backend, ReadOnly in Terraform",
                     "computed_optional_required": "computed",
                     "element_type": {
                       "string": {}


### PR DESCRIPTION
Fixed issue where externally mapped users would show up when planning and applying resources. As this is a resource that is completely managed and handled by the backend we don't want it interfering with any Terraform actions.

To add this feature we created a custom `plan_modifier` that tells Terraform to always use the current `state` of the field from the API and use that in the plan, so this will mean that it never shows any changes when planning or applying.