### PR TITLE
Update console platform and permissions

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
-CONDUKTOR_CONSOLE_IMAGE=conduktor/conduktor-console:1.33.0
-CONDUKTOR_CONSOLE_CORTEX_IMAGE=conduktor/conduktor-console-cortex:1.33.0
-CONDUKTOR_GATEWAY_IMAGE=conduktor/conduktor-gateway:3.8.1
+CONDUKTOR_CONSOLE_IMAGE=conduktor/conduktor-console:1.34.0
+CONDUKTOR_CONSOLE_CORTEX_IMAGE=conduktor/conduktor-console-cortex:1.34.0
+CONDUKTOR_GATEWAY_IMAGE=conduktor/conduktor-gateway:3.9.0
 CDK_BASE_URL=http://localhost:8080
 CDK_ADMIN_EMAIL=admin@conduktor.io
 CDK_ADMIN_PASSWORD=testP4ss!

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,10 +77,11 @@ jobs:
           #- "1.30.0"
           #- "1.31.0"
           #- "1.32.0"
-          - "1.33.0"
+          #- "1.33.0"
+          - "1.34.0"
         gateway:
           - "3.5.2"
-          - "3.8.1"
+          - "3.9.0"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/internal/schema/validation/schema_validation.go
+++ b/internal/schema/validation/schema_validation.go
@@ -27,7 +27,6 @@ var ValidPermissions = []string{
 	"datamaskingView",
 	"userView",
 	"datamaskingManage",
-	"notificationChannelView",
 	"subjectCreateUpdate",
 	"subjectEditCompatibility",
 	"subjectDelete",

--- a/internal/schema/validation/schema_validation.go
+++ b/internal/schema/validation/schema_validation.go
@@ -39,6 +39,8 @@ var ValidPermissions = []string{
 	"topicCreate",
 	"topicAddPartition",
 	"topicDelete",
+	"chargebackManage",
+	"sqlManage",
 }
 
 // Provider modes.


### PR DESCRIPTION
- Update console and gateway version to latest releases. 
- Update supported permissions by removing deprecated `notificationChannelView` and adding new permissions `chargebackManage` and `sqlManage`.