### PR TITLE
feat: new policy_ref field added to application instance

### DIFF
--- a/docs/resources/console_application_instance_v1.md
+++ b/docs/resources/console_application_instance_v1.md
@@ -103,6 +103,7 @@ Optional:
 
 - `application_managed_service_account` (Boolean) If set to true, the service account ACLs will be managed by the Application owners directly instead of being synchronized by the ApplicationInstance component. See [documentation](https://docs.conduktor.io/platform/reference/resource-reference/self-service/#application-managed-service-account) for more information
 - `default_catalog_visibility` (String) Default catalog visibility for the application instance, valid values are: PRIVATE, PUBLIC
+- `policy_ref` (Set of String) Reference to the resource policy to apply to this instance
 - `resources` (Attributes Set) Set of all resources associated with this application instance (see [below for nested schema](#nestedatt--spec--resources))
 - `service_account` (String) Service account associated with this application instance
 - `topic_policy_ref` (Set of String) Reference to the topic policy to apply to this instance

--- a/internal/mapper/console_application_instance_v1/console_application_instance_v1_resource_mapper_test.go
+++ b/internal/mapper/console_application_instance_v1/console_application_instance_v1_resource_mapper_test.go
@@ -44,6 +44,7 @@ func TestApplicationInstanceV1ModelMapping(t *testing.T) {
 	assert.Equal(t, "app", internal.Metadata.Application)
 	assert.Equal(t, "cluster", internal.Spec.Cluster)
 	assert.Equal(t, []string{"ref2", "ref1"}, internal.Spec.TopicPolicyRef)
+	assert.Equal(t, []string{"resourcepolicy1", "resourcepolicy2"}, internal.Spec.PolicyRef)
 	assert.Equal(t, false, internal.Spec.ApplicationManagedServiceAccount)
 	assert.Equal(t, "serviceaccount", internal.Spec.ServiceAccount)
 	assert.Equal(t, "PRIVATE", internal.Spec.DefaultCatalogVisibility)
@@ -72,10 +73,12 @@ func TestApplicationInstanceV1ModelMapping(t *testing.T) {
 		return
 	}
 	topicPolicyRef, _ := schema.StringArrayToSetValue([]string{"ref2", "ref1"})
+	policyRef, _ := schema.StringArrayToSetValue([]string{"resourcepolicy1", "resourcepolicy2"})
 	assert.Equal(t, types.StringValue("appinstance"), tfModel.Name)
 	assert.Equal(t, types.StringValue("app"), tfModel.Application)
 	assert.Equal(t, types.StringValue("cluster"), tfModel.Spec.Cluster)
 	assert.Equal(t, topicPolicyRef, tfModel.Spec.TopicPolicyRef)
+	assert.Equal(t, policyRef, tfModel.Spec.PolicyRef)
 	assert.Equal(t, types.BoolValue(false), tfModel.Spec.ApplicationManagedServiceAccount)
 	assert.Equal(t, types.StringValue("serviceaccount"), tfModel.Spec.ServiceAccount)
 	assert.Equal(t, types.StringValue("PRIVATE"), tfModel.Spec.DefaultCatalogVisibility)
@@ -94,6 +97,7 @@ func TestApplicationInstanceV1ModelMapping(t *testing.T) {
 	assert.Equal(t, "app", internal2.Metadata.Application)
 	assert.Equal(t, "cluster", internal2.Spec.Cluster)
 	assert.Equal(t, []string{"ref2", "ref1"}, internal2.Spec.TopicPolicyRef)
+	assert.Equal(t, []string{"resourcepolicy1", "resourcepolicy2"}, internal2.Spec.PolicyRef)
 	assert.Equal(t, false, internal2.Spec.ApplicationManagedServiceAccount)
 	assert.Equal(t, "serviceaccount", internal2.Spec.ServiceAccount)
 	assert.Equal(t, "PRIVATE", internal2.Spec.DefaultCatalogVisibility)

--- a/internal/model/console/application_instance_v1.go
+++ b/internal/model/console/application_instance_v1.go
@@ -32,6 +32,7 @@ func (r ApplicationInstanceConsoleMetadata) String() string {
 type ApplicationInstanceConsoleSpec struct {
 	Cluster                          string                  `json:"cluster"`
 	TopicPolicyRef                   []string                `json:"topicPolicyRef,omitempty"`
+	PolicyRef                        []string                `json:"policyRef,omitempty"`
 	Resources                        []ResourceWithOwnership `json:"resources,omitempty"`
 	ApplicationManagedServiceAccount bool                    `json:"applicationManagedServiceAccount"`
 	ServiceAccount                   string                  `json:"serviceAccount,omitempty"`

--- a/internal/provider/console_application_instance_v1_resource_test.go
+++ b/internal/provider/console_application_instance_v1_resource_test.go
@@ -66,6 +66,38 @@ func TestAccApplicationInstanceV1Resource(t *testing.T) {
 	})
 }
 
+// This test contains a resource definition for creating an application instance targeting specifically Conduktor Console v1.34.
+// Currently used to test the new `spec.policy_ref` field.
+func TestAccApplicationInstanceV1Resource2(t *testing.T) {
+	v, err := fetchClientVersion(client.CONSOLE)
+	if err != nil {
+		t.Fatalf("Error fetching current version: %s", err)
+	}
+	test.CheckMinimumVersionRequirement(t, v, "v1.34.0")
+
+	resourceRef := "conduktor_console_application_instance_v1.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: providerConfigConsole + test.TestAccTestdata(t, "console/application_instance_v1/resource_create_2.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceRef, "name", "appinstance"),
+					resource.TestCheckResourceAttr(resourceRef, "application", "myapp"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.cluster", "kafka-cluster"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.policy_ref.#", "1"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.policy_ref.0", "resource-policy"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.application_managed_service_account", "false"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.service_account", "my-service-account"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func TestAccApplicationInstanceV1Minimal(t *testing.T) {
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {

--- a/internal/testdata/console/application_instance_v1/api.json
+++ b/internal/testdata/console/application_instance_v1/api.json
@@ -11,6 +11,10 @@
       "ref2",
       "ref1"
     ],
+    "policyRef": [
+      "resourcepolicy1",
+      "resourcepolicy2"
+    ],
     "resources": [
       {
         "type": "CONSUMER_GROUP",

--- a/internal/testdata/console/application_instance_v1/resource_create_2.tf
+++ b/internal/testdata/console/application_instance_v1/resource_create_2.tf
@@ -1,0 +1,28 @@
+
+# This file contains a resource definition for creating an application instance targeting specifically Conduktor Console v1.34.
+# Currently used to test the new `spec.policy_ref` field.
+resource "conduktor_console_resource_policy_v1" "this" {
+  name = "resource-policy"
+  spec = {
+    target_kind = "Connector"
+    rules = [
+      {
+        condition     = "spec.replicationFactor == 3"
+        error_message = "replication factor should be 3"
+      }
+    ]
+  }
+}
+
+resource "conduktor_console_application_instance_v1" "test" {
+  name        = "appinstance"
+  application = "myapp"
+  spec = {
+    cluster = "kafka-cluster"
+    policy_ref = [
+      conduktor_console_resource_policy_v1.this.name
+    ]
+    application_managed_service_account = false
+    service_account                     = "my-service-account"
+  }
+}

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -255,6 +255,16 @@
                   }
                 },
                 {
+                  "name": "policy_ref",
+                  "set": {
+                    "description": "Reference to the resource policy to apply to this instance",
+                    "computed_optional_required": "optional",
+                    "element_type": {
+                      "string": {}
+                    }
+                  }
+                },
+                {
                   "name": "resources",
                   "set_nested": {
                     "description": "Set of all resources associated with this application instance",


### PR DESCRIPTION
Adding support for new `spec.policy_ref` field to `conduktor_console_application_instance_v1`

introduced with Conduktor Console v1.34.0

Example:

```hcl
resource "conduktor_console_resource_policy_v1" "this" {
  name = "resource-policy"
  spec = {
    target_kind = "Connector"
    rules = [
      {
        condition     = "spec.replicationFactor == 3"
        error_message = "replication factor should be 3"
      }
    ]
  }
}

resource "conduktor_console_application_instance_v1" "test" {
  name        = "appinstance"
  application = "myapp"
  spec = {
    cluster = "kafka-cluster"
    policy_ref = [
      conduktor_console_resource_policy_v1.this.name
    ]
    application_managed_service_account = false
    service_account                     = "my-service-account"
  }
}

```