### PR TITLE
Update Console and Gateway version used for tests 

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
-CONDUKTOR_CONSOLE_IMAGE=conduktor/conduktor-console:1.40.0
-CONDUKTOR_CONSOLE_CORTEX_IMAGE=conduktor/conduktor-console-cortex:1.40.0
-CONDUKTOR_GATEWAY_IMAGE=conduktor/conduktor-gateway:3.15.0
+CONDUKTOR_CONSOLE_IMAGE=conduktor/conduktor-console:1.45.1
+CONDUKTOR_CONSOLE_CORTEX_IMAGE=conduktor/conduktor-console-cortex:1.45.1
+CONDUKTOR_GATEWAY_IMAGE=conduktor/conduktor-gateway:3.19.1
 CDK_BASE_URL=http://localhost:8080
 CDK_ADMIN_EMAIL=admin@conduktor.io
 CDK_ADMIN_PASSWORD=testP4ss!

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,21 +77,21 @@ jobs:
           - console: "1.26.0"
             gateway: "3.5.2"
             terraform:
-               version: "1.0.*"
-               name: "TF-1.0"
+              version: "1.0.*"
+              name: "TF-1.0"
             license: v2
 
           # latest versions no license
-          - console: "1.40.0"
-            gateway: "3.15.0"
+          - console: "1.45.1"
+            gateway: "3.15.0" # latest Gateway version that support no license startup
             terraform:
-                version: "latest"
-                name: "TF-latest"
+              version: "latest"
+              name: "TF-latest"
             license: free
 
           # latest versions with license
-          - console: "1.40.0"
-            gateway: "3.15.0"
+          - console: "1.45.1"
+            gateway: "3.19.1"
             terraform:
               version: "latest"
               name: "TF-latest"
@@ -135,7 +135,7 @@ jobs:
           elif [[ "${{ matrix.env.license }}" == "v3" ]]; then
             license="${{ secrets.TEST_LICENSE_V3 }}"
           fi
-          
+
           # only set license if it is not empty
           # can be empty for free tier testing, dependabot or external PRs
           # Note : old versions of Console fail health probe if license is set emtpy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -105,9 +105,9 @@ services:
       CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
       CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
       CONNECT_KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: 'http://redpanda:8081'
+      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: "http://redpanda:8081"
       CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://redpanda:8081'
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: "http://redpanda:8081"
       CONNECT_INTERNAL_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
       CONNECT_INTERNAL_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
       CONNECT_REST_ADVERTISED_HOST_NAME: "kafka-connect"
@@ -116,7 +116,7 @@ services:
       CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: "1"
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: "1"
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: "1"
-      CONNECT_PLUGIN_PATH: '/usr/share/java,/etc/kafka-connect/jars,/usr/share/confluent-hub-components'
+      CONNECT_PLUGIN_PATH: "/usr/share/java,/etc/kafka-connect/jars,/usr/share/confluent-hub-components"
     healthcheck:
       interval: 5s
       retries: 20
@@ -127,6 +127,7 @@ services:
   conduktor-gateway:
     image: ${CONDUKTOR_GATEWAY_IMAGE}
     hostname: gateway
+    restart: no
     ports:
       - "9094:9094"
       - "8888:8888"

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -338,3 +338,56 @@ func (client *Client) GetAPIVersion(ctx context.Context, mode Mode) (string, err
 	// Go module semver requires version to start with v.
 	return "v" + version, nil
 }
+
+// GetConsoleLicensePlan returns the Console license plan ("free" or "enterprise").
+// It first fetches the default org slug from GET /api/organizations,
+// then fetches the license info from GET /api/organizations/{slug}/platform-license.
+func (client *Client) GetConsoleLicensePlan(ctx context.Context) (string, error) {
+	// Get the default organization slug
+	orgsURL := client.BaseUrl + "/api/organizations"
+	orgsResp, err := client.Client.R().Get(orgsURL)
+	if err != nil {
+		return "", fmt.Errorf("error fetching organizations: %s", err)
+	} else if orgsResp.IsError() {
+		return "", fmt.Errorf("error fetching organizations: %s", ExtractApiError(orgsResp))
+	}
+	tflog.Trace(ctx, fmt.Sprintf("GET /api/organizations response : %s", string(orgsResp.Body())))
+
+	var orgs []map[string]any
+	err = json.Unmarshal(orgsResp.Body(), &orgs)
+	if err != nil {
+		return "", fmt.Errorf("error parsing organizations response: %s", err)
+	}
+	if len(orgs) == 0 {
+		return "", fmt.Errorf("no organizations found")
+	}
+
+	slug, ok := orgs[0]["slug"].(string)
+	if !ok || slug == "" {
+		return "", fmt.Errorf("no slug found in organization response")
+	}
+
+	// Fetch the license info for the organization
+	licensePath := fmt.Sprintf("/api/organizations/%s/platform-license", slug)
+	licenseURL := client.BaseUrl + licensePath
+	licenseResp, err := client.Client.R().Get(licenseURL)
+	if err != nil {
+		return "", fmt.Errorf("error fetching license info: %s", err)
+	} else if licenseResp.IsError() {
+		return "", fmt.Errorf("error fetching license info: %s", ExtractApiError(licenseResp))
+	}
+	tflog.Trace(ctx, fmt.Sprintf("GET %s response : %s", licensePath, string(licenseResp.Body())))
+
+	var licenseInfo map[string]any
+	err = json.Unmarshal(licenseResp.Body(), &licenseInfo)
+	if err != nil {
+		return "", fmt.Errorf("error parsing license response: %s", err)
+	}
+
+	plan, ok := licenseInfo["plan"].(string)
+	if !ok || plan == "" {
+		return "", fmt.Errorf("no plan found in license response")
+	}
+
+	return plan, nil
+}

--- a/internal/provider/console_application_group_v1_resource.go
+++ b/internal/provider/console_application_group_v1_resource.go
@@ -15,6 +15,7 @@ import (
 )
 
 const applicationGroupV1ApiPath = "/public/self-serve/v1/application-group"
+const applicationGroupV1EnterpriseOnlyVersion = "v1.43.0"
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &ApplicationGroupV1Resource{}
@@ -61,6 +62,17 @@ func (r *ApplicationGroupV1Resource) Configure(ctx context.Context, req resource
 				"More info here: \n"+
 				" - https://registry.terraform.io/providers/conduktor/conduktor/latest/docs",
 		)
+		return
+	}
+
+	consoleVersion, err := data.Client.GetAPIVersion(ctx, client.CONSOLE)
+	if err != nil {
+		resp.Diagnostics.AddError("Error fetching Console version", err.Error())
+		return
+	}
+
+	checkEnterprisePlanRequirement(ctx, data.Client, consoleVersion, applicationGroupV1EnterpriseOnlyVersion, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/console_application_group_v1_resource_test.go
+++ b/internal/provider/console_application_group_v1_resource_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccApplicationGroupV1Resource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	resourceRef := "conduktor_console_application_group_v1.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
@@ -73,6 +74,7 @@ func TestAccApplicationGroupV1Resource(t *testing.T) {
 }
 
 func TestAccApplicationGroupV1Minimal(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -92,6 +94,7 @@ func TestAccApplicationGroupV1Minimal(t *testing.T) {
 }
 
 func TestAccApplicationGroupV1ExampleResource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/console_application_instance_permission_v1_resource.go
+++ b/internal/provider/console_application_instance_permission_v1_resource.go
@@ -17,6 +17,7 @@ import (
 
 const applicationInstancePermissionV1ApiPath = "/public/self-serve/v1/application-instance-permission"
 const applicationInstancePermissionMininumVersion = "v1.33.0"
+const applicationInstancePermissionEnterpriseOnlyVersion = "v1.43.0"
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &ApplicationInstancePermissionV1Resource{}
@@ -79,6 +80,11 @@ func (r *ApplicationInstancePermissionV1Resource) Configure(ctx context.Context,
 			"Minimum version requirement not met",
 			"This resource requires Conduktor Console API version "+applicationInstancePermissionMininumVersion+" but targeted Conduktor Console API is "+consoleVersion,
 		)
+		return
+	}
+
+	checkEnterprisePlanRequirement(ctx, data.Client, consoleVersion, applicationInstancePermissionEnterpriseOnlyVersion, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/console_application_instance_permission_v1_resource_test.go
+++ b/internal/provider/console_application_instance_permission_v1_resource_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccApplicationInstancePermissionV1Resource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -65,6 +66,7 @@ func TestAccApplicationInstancePermissionV1Resource(t *testing.T) {
 }
 
 func TestAccApplicationInstancePermissionV1ExampleResource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)

--- a/internal/provider/console_application_instance_v1_resource.go
+++ b/internal/provider/console_application_instance_v1_resource.go
@@ -12,10 +12,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	jsoniter "github.com/json-iterator/go"
+	"golang.org/x/mod/semver"
 )
 
 const applicationInstanceV1ApiPath = "/public/self-serve/v1/application-instance"
 const appInstanceMininumVersion = "v1.31.0"
+const appInstanceEnterpriseOnlyVersion = "v1.43.0"
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &ApplicationInstanceV1Resource{}
@@ -62,6 +64,24 @@ func (r *ApplicationInstanceV1Resource) Configure(ctx context.Context, req resou
 				"More info here: \n"+
 				" - https://registry.terraform.io/providers/conduktor/conduktor/latest/docs",
 		)
+		return
+	}
+
+	consoleVersion, err := data.Client.GetAPIVersion(ctx, client.CONSOLE)
+	if err != nil {
+		resp.Diagnostics.AddError("Error fetching Console version", err.Error())
+		return
+	}
+	if semver.IsValid(consoleVersion) && semver.Compare(consoleVersion, appInstanceMininumVersion) < 0 {
+		resp.Diagnostics.AddError(
+			"Minimum version requirement not met",
+			"This resource requires Conduktor Console API version "+appInstanceMininumVersion+" but targeted Conduktor Console API is "+consoleVersion,
+		)
+		return
+	}
+
+	checkEnterprisePlanRequirement(ctx, data.Client, consoleVersion, appInstanceEnterpriseOnlyVersion, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/console_application_instance_v1_resource_test.go
+++ b/internal/provider/console_application_instance_v1_resource_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccApplicationInstanceV1Resource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -69,6 +70,7 @@ func TestAccApplicationInstanceV1Resource(t *testing.T) {
 // This test contains a resource definition for creating an application instance targeting specifically Conduktor Console v1.34.
 // Currently used to test the new `spec.policy_ref` field.
 func TestAccApplicationInstanceV1Resource2(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -99,6 +101,7 @@ func TestAccApplicationInstanceV1Resource2(t *testing.T) {
 }
 
 func TestAccApplicationInstanceV1Minimal(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -123,6 +126,7 @@ func TestAccApplicationInstanceV1Minimal(t *testing.T) {
 }
 
 func TestAccApplicationInstanceV1ExampleResource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)

--- a/internal/provider/console_application_v1_resource.go
+++ b/internal/provider/console_application_v1_resource.go
@@ -15,6 +15,7 @@ import (
 )
 
 const applicationV1ApiPath = "/public/self-serve/v1/application"
+const applicationV1EnterpriseOnlyVersion = "v1.43.0"
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &ApplicationV1Resource{}
@@ -61,6 +62,17 @@ func (r *ApplicationV1Resource) Configure(ctx context.Context, req resource.Conf
 				"More info here: \n"+
 				" - https://registry.terraform.io/providers/conduktor/conduktor/latest/docs",
 		)
+		return
+	}
+
+	consoleVersion, err := data.Client.GetAPIVersion(ctx, client.CONSOLE)
+	if err != nil {
+		resp.Diagnostics.AddError("Error fetching Console version", err.Error())
+		return
+	}
+
+	checkEnterprisePlanRequirement(ctx, data.Client, consoleVersion, applicationV1EnterpriseOnlyVersion, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/console_application_v1_resource_test.go
+++ b/internal/provider/console_application_v1_resource_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccApplicationV1Resource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	resourceRef := "conduktor_console_application_v1.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
@@ -48,6 +49,7 @@ func TestAccApplicationV1Resource(t *testing.T) {
 }
 
 func TestAccApplicationV1ExampleResource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/console_connector_v2_resource_test.go
+++ b/internal/provider/console_connector_v2_resource_test.go
@@ -1,15 +1,17 @@
 package provider
 
 import (
-	"github.com/conduktor/terraform-provider-conduktor/internal/client"
-	"github.com/conduktor/terraform-provider-conduktor/internal/test"
 	"regexp"
 	"testing"
+
+	"github.com/conduktor/terraform-provider-conduktor/internal/client"
+	"github.com/conduktor/terraform-provider-conduktor/internal/test"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccConnectorV2Resource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t) // skip when no license because Gateway will likely not be up
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -70,6 +72,7 @@ func TestAccConnectorV2Resource(t *testing.T) {
 }
 
 func TestAccConnectorV2Minimal(t *testing.T) {
+	test.CheckEnterpriseEnabled(t) // skip when no license because Gateway will likely not be up
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -99,6 +102,7 @@ func TestAccConnectorV2Minimal(t *testing.T) {
 }
 
 func TestAccConnectorV2Labels(t *testing.T) {
+	test.CheckEnterpriseEnabled(t) // skip when no license because Gateway will likely not be up
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -125,6 +129,7 @@ func TestAccConnectorV2Labels(t *testing.T) {
 }
 
 func TestAccConnectorV2ExampleSimpleResource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t) // skip when no license because Gateway will likely not be up
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -155,6 +160,7 @@ func TestAccConnectorV2ExampleSimpleResource(t *testing.T) {
 }
 
 func TestAccConnectorV2ExampleComplexResource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t) // skip when no license because Gateway will likely not be up
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)

--- a/internal/provider/console_resource_policy_v1_resource.go
+++ b/internal/provider/console_resource_policy_v1_resource.go
@@ -17,6 +17,7 @@ import (
 
 const resourcePolicyV1ApiPath = "/public/self-serve/v1/resource-policy"
 const resourcePolicyMininumVersion = "v1.34.0"
+const resourcePolicyEnterpriseOnlyVersion = "v1.43.0"
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &ResourcePolicyV1Resource{}
@@ -79,6 +80,11 @@ func (r *ResourcePolicyV1Resource) Configure(ctx context.Context, req resource.C
 			"Minimum version requirement not met",
 			"This resource requires Conduktor Console API version "+resourcePolicyMininumVersion+" but targeted Conduktor Console API is "+consoleVersion,
 		)
+		return
+	}
+
+	checkEnterprisePlanRequirement(ctx, data.Client, consoleVersion, resourcePolicyEnterpriseOnlyVersion, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/console_resource_policy_v1_resource_test.go
+++ b/internal/provider/console_resource_policy_v1_resource_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccResourcePolicyV1Resource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -62,6 +63,7 @@ func TestAccResourcePolicyV1Resource(t *testing.T) {
 }
 
 func TestAccResourcePolicyV1Minimal(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -89,6 +91,7 @@ func TestAccResourcePolicyV1Minimal(t *testing.T) {
 }
 
 func TestAccResourcePolicyV1ExampleResource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)

--- a/internal/provider/console_topic_policy_v1_resource.go
+++ b/internal/provider/console_topic_policy_v1_resource.go
@@ -14,10 +14,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	jsoniter "github.com/json-iterator/go"
+	"golang.org/x/mod/semver"
 )
 
 const topicPolicyV1ApiPath = "/public/self-serve/v1/topic-policy"
 const topicPolicyMininumVersion = "v1.30.0"
+const topicPolicyEnterpriseOnlyVersion = "v1.43.0"
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &TopicPolicyV1Resource{}
@@ -40,7 +42,7 @@ func (r *TopicPolicyV1Resource) Schema(ctx context.Context, _ resource.SchemaReq
 	resp.Schema = schema.ConsoleTopicPolicyV1ResourceSchema(ctx)
 }
 
-func (r *TopicPolicyV1Resource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *TopicPolicyV1Resource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
 		return
@@ -64,6 +66,24 @@ func (r *TopicPolicyV1Resource) Configure(_ context.Context, req resource.Config
 				"More info here: \n"+
 				" - https://registry.terraform.io/providers/conduktor/conduktor/latest/docs",
 		)
+		return
+	}
+
+	consoleVersion, err := data.Client.GetAPIVersion(ctx, client.CONSOLE)
+	if err != nil {
+		resp.Diagnostics.AddError("Error fetching Console version", err.Error())
+		return
+	}
+	if semver.IsValid(consoleVersion) && semver.Compare(consoleVersion, topicPolicyMininumVersion) < 0 {
+		resp.Diagnostics.AddError(
+			"Minimum version requirement not met",
+			"This resource requires Conduktor Console API version "+topicPolicyMininumVersion+" but targeted Conduktor Console API is "+consoleVersion,
+		)
+		return
+	}
+
+	checkEnterprisePlanRequirement(ctx, data.Client, consoleVersion, topicPolicyEnterpriseOnlyVersion, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/console_topic_policy_v1_resource_test.go
+++ b/internal/provider/console_topic_policy_v1_resource_test.go
@@ -12,6 +12,11 @@ import (
 
 func TestAccTopicPolicyV1Resource(t *testing.T) {
 	test.CheckEnterpriseEnabled(t)
+	v, err := fetchClientVersion(client.CONSOLE)
+	if err != nil {
+		t.Fatalf("Error fetching current version: %s", err)
+	}
+	test.CheckMinimumVersionRequirement(t, v, topicPolicyMininumVersion)
 	resourceRef := "conduktor_console_topic_policy_v1.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
@@ -52,6 +57,11 @@ func TestAccTopicPolicyV1Resource(t *testing.T) {
 
 func TestAccTopicPolicyV1Minimal(t *testing.T) {
 	test.CheckEnterpriseEnabled(t)
+	v, err := fetchClientVersion(client.CONSOLE)
+	if err != nil {
+		t.Fatalf("Error fetching current version: %s", err)
+	}
+	test.CheckMinimumVersionRequirement(t, v, topicPolicyMininumVersion)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -72,6 +82,11 @@ func TestAccTopicPolicyV1Minimal(t *testing.T) {
 
 func TestAccTopicPolicyV1Constraints(t *testing.T) {
 	test.CheckEnterpriseEnabled(t)
+	v, err := fetchClientVersion(client.CONSOLE)
+	if err != nil {
+		t.Fatalf("Error fetching current version: %s", err)
+	}
+	test.CheckMinimumVersionRequirement(t, v, topicPolicyMininumVersion)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/console_topic_policy_v1_resource_test.go
+++ b/internal/provider/console_topic_policy_v1_resource_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccTopicPolicyV1Resource(t *testing.T) {
-
+	test.CheckEnterpriseEnabled(t)
 	resourceRef := "conduktor_console_topic_policy_v1.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
@@ -51,6 +51,7 @@ func TestAccTopicPolicyV1Resource(t *testing.T) {
 }
 
 func TestAccTopicPolicyV1Minimal(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -85,6 +86,7 @@ func TestAccTopicPolicyV1Constraints(t *testing.T) {
 }
 
 func TestAccTopicPolicyV1ExampleResource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)

--- a/internal/provider/gateway_virtual_cluster_v2_resource_test.go
+++ b/internal/provider/gateway_virtual_cluster_v2_resource_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccGatewayVirtualClusterV2Resource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.GATEWAY)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -80,6 +81,7 @@ func TestAccGatewayVirtualClusterV2Resource(t *testing.T) {
 }
 
 func TestAccVirtualClusterV2Minimal(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.GATEWAY)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)
@@ -103,6 +105,7 @@ func TestAccVirtualClusterV2Minimal(t *testing.T) {
 }
 
 func TestAccVirtualClusterV2ExampleResource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.GATEWAY)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,8 +8,10 @@ import (
 	"github.com/conduktor/terraform-provider-conduktor/internal/client"
 	schemaUtils "github.com/conduktor/terraform-provider-conduktor/internal/schema"
 	schema "github.com/conduktor/terraform-provider-conduktor/internal/schema/provider_conduktor"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"golang.org/x/mod/semver"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/function"
@@ -198,4 +200,43 @@ func New(version, commit, date string) func() provider.Provider {
 			date:    date,
 		}
 	}
+}
+
+// checkEnterprisePlanRequirement checks if the Console license plan is compatible with
+// resources that became enterprise-only starting from a given version.
+// - On free plan + Console >= enterpriseOnlyVersion: adds an error diagnostic.
+// - On free plan + Console < enterpriseOnlyVersion: adds a warning diagnostic.
+// - On any other plan (enterprise, trial, console-monthly, passthrough-gateway): no diagnostic.
+// - On error fetching the plan: adds a warning diagnostic (graceful degradation).
+// Callers should check resp.Diagnostics.HasError() after calling this function.
+func checkEnterprisePlanRequirement(ctx context.Context, apiClient *client.Client, consoleVersion string, enterpriseOnlyVersion string, diagnostics *diag.Diagnostics) { //nolint:unparam // enterpriseOnlyVersion is parameterized for future per-resource version flexibility
+	consolePlan, err := apiClient.GetConsoleLicensePlan(ctx)
+	if err != nil {
+		diagnostics.AddWarning(
+			"Unable to check Console license plan",
+			"Could not determine Console license plan: "+err.Error()+". Enterprise license may be required for this resource.",
+		)
+		return
+	}
+
+	if consolePlan != "free" {
+		return
+	}
+
+	if semver.IsValid(consoleVersion) && semver.Compare(consoleVersion, enterpriseOnlyVersion) >= 0 {
+		diagnostics.AddError(
+			"Enterprise license required",
+			"This resource requires an Enterprise license on Conduktor Console version "+enterpriseOnlyVersion+" or later. "+
+				"Current Console is "+consoleVersion+" running on the Community (free) plan. "+
+				"Please upgrade to an Enterprise license to use this resource.",
+		)
+		return
+	}
+
+	diagnostics.AddWarning(
+		"Enterprise license will be required",
+		"This resource will require an Enterprise license starting from Conduktor Console version "+enterpriseOnlyVersion+". "+
+			"Current Console is "+consoleVersion+" running on the Community (free) plan. "+
+			"Please plan to upgrade to an Enterprise license.",
+	)
 }

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -31,6 +31,9 @@ export CDK_USER=${CONSOLE_USER}
 export CDK_PASSWORD=${CONSOLE_PASSWORD}
 CDK_DEBUG=false go run github.com/conduktor/ctl@${CLI_VERSION} login # disable debug logs for the login
 go run github.com/conduktor/ctl@${CLI_VERSION} apply -f "${SCRIPT_DIR}"/../testdata/init/init_console.yaml
+if [[ -n "${CDK_LICENSE:-}" ]]; then # enterprise-only resources require a license on Console >= 1.43.0
+	go run github.com/conduktor/ctl@${CLI_VERSION} apply -f "${SCRIPT_DIR}"/../testdata/init/init_console_enterprise.yaml
+fi
 if [[ "${CONDUKTOR_CONSOLE_IMAGE}" != *"1.26.0"* ]];then # only applying some resources for newer console versions
 	go run github.com/conduktor/ctl@${CLI_VERSION} apply -f "${SCRIPT_DIR}"/../testdata/init/init_console_1.27+.yaml
 fi

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -38,11 +38,17 @@ if [[ "${CONDUKTOR_CONSOLE_IMAGE}" != *"1.26.0"* ]];then # only applying some re
 	go run github.com/conduktor/ctl@${CLI_VERSION} apply -f "${SCRIPT_DIR}"/../testdata/init/init_console_1.27+.yaml
 fi
 
-echo "Logging in Gateway and applying setup"
-unset CDK_BASE_URL
-unset CDK_USER
-unset CDK_PASSWORD
-export CDK_GATEWAY_BASE_URL=${GW_URL}
-export CDK_GATEWAY_USER=${GW_USER}
-export CDK_GATEWAY_PASSWORD=${GW_PASSWORD}
-go run github.com/conduktor/ctl@${CLI_VERSION} apply -f "${SCRIPT_DIR}"/../testdata/init/init_gateway.yaml
+# Only seed gateway if the container is running and healthy
+GATEWAY_CONTAINER_ID=$(docker container ls -a --filter "name=conduktor-gateway" --filter "status=running" --format "{{.ID}}")
+if [ -n "$GATEWAY_CONTAINER_ID" ] && [ "$(docker inspect -f {{.State.Health.Status}} "$GATEWAY_CONTAINER_ID" 2>/dev/null)" = "healthy" ]; then
+	echo "Logging in Gateway and applying setup"
+	unset CDK_BASE_URL
+	unset CDK_USER
+	unset CDK_PASSWORD
+	export CDK_GATEWAY_BASE_URL=${GW_URL}
+	export CDK_GATEWAY_USER=${GW_USER}
+	export CDK_GATEWAY_PASSWORD=${GW_PASSWORD}
+	go run github.com/conduktor/ctl@${CLI_VERSION} apply -f "${SCRIPT_DIR}"/../testdata/init/init_gateway.yaml
+else
+	echo "Gateway container is not healthy, skipping Gateway setup"
+fi

--- a/scripts/wait_for_test_env_ready.sh
+++ b/scripts/wait_for_test_env_ready.sh
@@ -16,16 +16,29 @@ until [ "$(docker inspect -f {{.State.Health.Status}} "$CONSOLE_CONTAINER_ID")" 
 done;
 echo "Conduktor Console container is ready!"
 
-# get the container name
+# Gateway container may fail to start without a license (version > 3.15.0).
+# In that case we just warn and continue — gateway tests will be skipped.
 GATEWAY_CONTAINER_ID=$(docker container ls -a --filter "name=conduktor-gateway" --filter "status=running" --format "{{.ID}}")
 if [ -z "$GATEWAY_CONTAINER_ID" ]; then
-    echo "Conduktor Gateway container not found. Exiting."
-    exit 1
+    echo "WARNING: Conduktor Gateway container is not running. Gateway tests will be skipped."
+else
+    echo "Waiting for the Conduktor Gateway container $GATEWAY_CONTAINER_ID to be ready..."
+    RETRIES=0
+    MAX_RETRIES=30
+    while [ "$RETRIES" -lt "$MAX_RETRIES" ]; do
+        STATUS=$(docker inspect -f {{.State.Health.Status}} "$GATEWAY_CONTAINER_ID" 2>/dev/null || echo "exited")
+        if [ "$STATUS" = "healthy" ]; then
+            echo "Conduktor Gateway container is ready!"
+            break
+        elif [ "$STATUS" = "unhealthy" ] || [ "$STATUS" = "exited" ]; then
+            echo "WARNING: Conduktor Gateway container failed to start (status: $STATUS). Gateway tests will be skipped."
+            break
+        fi
+        sleep 2;
+        printf "."
+        RETRIES=$((RETRIES + 1))
+    done
+    if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+        echo "WARNING: Conduktor Gateway container did not become healthy in time. Gateway tests will be skipped."
+    fi
 fi
-
-echo "Waiting for the Conduktor Gateway container $GATEWAY_CONTAINER_ID to be ready..."
-until [ "$(docker inspect -f {{.State.Health.Status}} "$GATEWAY_CONTAINER_ID")" == "healthy" ]; do
-    sleep 1;
-    printf "."
-done;
-echo "Conduktor Gateway container is ready!"

--- a/testdata/init/init_console.yaml
+++ b/testdata/init/init_console.yaml
@@ -9,7 +9,7 @@ spec:
   bootstrapServers: redpanda:9092
   # properties:
   #   sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";
-  color: '#FF0000'
+  color: "#FF0000"
   icon: icon
   schemaRegistry:
     type: "ConfluentLike"
@@ -29,7 +29,7 @@ spec:
     sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="console" password="eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImNvbnNvbGUiLCJ2Y2x1c3RlciI6InBhc3N0aHJvdWdoIiwiZXhwIjoxOTEzNTI5OTI2fQ.PaSEJkxyeC6pUJk_piRavAQPxCyN3c7HDAjPkubH9ZI";
     security.protocol: SASL_PLAINTEXT
     sasl.mechanism: PLAIN
-  color: '#FF0000'
+  color: "#FF0000"
   icon: icon
   kafkaFlavor:
     url: http://gateway:8888
@@ -47,44 +47,3 @@ spec:
   displayName: My kafka connect
   urls: http://kafka-connect:8083
   ignoreUntrustedCertificate: true
----
-apiVersion: v1
-kind: Application
-metadata:
-  name: myapp
-spec:
-  title: My Application
-  owner: admin
----
-apiVersion: v1
-kind: ApplicationInstance
-metadata:
-  name: my-app-instance
-  application: myapp
-spec:
-  cluster: kafka-cluster
-  resources:
-    - type: TOPIC
-      name: my-topic
-      patternType: LITERAL
----
-apiVersion: v1
-kind: ApplicationInstance
-metadata:
-  name: another-app-instance
-  application: myapp
-spec:
-  cluster: kafka-cluster
----
-apiVersion: v1
-kind: TopicPolicy
-metadata:
-  name: topic-policy
-spec:
-  policies:
-    my-policy:
-      constraint: OneOf
-      optional: true
-      values:
-        - value1
-        - value2

--- a/testdata/init/init_console_enterprise.yaml
+++ b/testdata/init/init_console_enterprise.yaml
@@ -1,0 +1,43 @@
+# Enterprise-only init manifests.
+# These resources require an Enterprise license on Console >= 1.43.0.
+---
+apiVersion: v1
+kind: Application
+metadata:
+  name: myapp
+spec:
+  title: My Application
+  owner: admin
+---
+apiVersion: v1
+kind: ApplicationInstance
+metadata:
+  name: my-app-instance
+  application: myapp
+spec:
+  cluster: kafka-cluster
+  resources:
+    - type: TOPIC
+      name: my-topic
+      patternType: LITERAL
+---
+apiVersion: v1
+kind: ApplicationInstance
+metadata:
+  name: another-app-instance
+  application: myapp
+spec:
+  cluster: kafka-cluster
+---
+apiVersion: v1
+kind: TopicPolicy
+metadata:
+  name: topic-policy
+spec:
+  policies:
+    my-policy:
+      constraint: OneOf
+      optional: true
+      values:
+        - value1
+        - value2


### PR DESCRIPTION
- Bump to latest Console 1.45.1 and Gateway 1.19.1 local dev env and CI tests enviroments. 
- Implement skip on resources no longer supported by Console in Community plan :
  -  `conduktor_console_application_v1`
  -  `conduktor_console_application_group_v1`
  - `conduktor_console_application_instance_v1`
  - `conduktor_console_application_instance_permission_v1`
  - `conduktor_console_resource_policy_v1`
  - `conduktor_console_topic_policy_v1`
- Skip tests on Gateway > 3.15.0 with Community license