### PR TITLE
Improve generic resource compatibility

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -182,8 +182,13 @@ func (client *Client) ApplyGeneric(ctx context.Context, cliResource ctlresource.
 
 	url := client.BaseUrl + applyPath.Path
 
-	tflog.Trace(ctx, fmt.Sprintf("PUT on %s body : %s", applyPath, string(cliResource.Json)))
 	builder := client.Client.R().SetBody(cliResource.Json)
+	// Required query params for kinds scoped by metadata, e.g. Alert v3 (#186).
+	for _, queryParam := range applyPath.QueryParams {
+		builder = builder.SetQueryParam(queryParam.Name, queryParam.Value)
+	}
+
+	tflog.Trace(ctx, fmt.Sprintf("PUT on %s body : %s", url, string(cliResource.Json)))
 	resp, err := builder.Put(url)
 	if err != nil {
 		return "", err

--- a/internal/provider/generic_resource.go
+++ b/internal/provider/generic_resource.go
@@ -3,6 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/conduktor/terraform-provider-conduktor/internal/customtypes"
 
 	ctlresource "github.com/conduktor/ctl/resource"
@@ -145,14 +148,22 @@ func (r *GenericResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	tflog.Trace(ctx, fmt.Sprintf("New resource JSON state : %s", string(firstResource.Json)))
 
-	// goyaml.FutureLineWrap()
-	var outBytes []byte
-	outBytes, err = yaml.JSONToYAML(firstResource.Json)
+	outBytes, err := yaml.JSONToYAML(firstResource.Json)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read Generic, got error: %s", err))
 		return
 	}
 	yamlString := string(outBytes)
+
+	// Keep only user-declared fields so server-computed ones (promQl, updatedAt...)
+	// don't cause a perpetual diff. Best-effort: fall back to the raw response.
+	if prior := data.Manifest.ValueString(); strings.TrimSpace(prior) != "" {
+		if reconciled, rerr := reconcileManifest(prior, yamlString); rerr != nil {
+			tflog.Warn(ctx, fmt.Sprintf("Unable to reconcile Generic manifest, using raw response: %s", rerr))
+		} else {
+			yamlString = reconciled
+		}
+	}
 	tflog.Trace(ctx, fmt.Sprintf("New resource YAML state : %s", yamlString))
 
 	data.Kind = schemaUtils.NewStringValue(firstResource.Kind)
@@ -249,8 +260,89 @@ func resourcePath(data schema.GenericModel) (string, error) {
 	if cluster != "" {
 		parentPath = append(parentPath, cluster)
 	}
-	// TODO support console alerts v3 query params https://github.com/conduktor/ctl/pull/78
-	parentQueryValues := []string{}
 
-	return kind.DescribePath(parentPath, parentQueryValues, data.Name.ValueString()).Path, nil
+	// Kinds scoped by metadata query params instead of a path segment, e.g. Alert
+	// v3's appInstance/group/user (#186). Sized-but-empty values keep DescribePath
+	// happy; the resolved params are appended to the final path.
+	queryParams, err := parentQueryParams(kind, data.Manifest.ValueString())
+	if err != nil {
+		return "", err
+	}
+
+	describe := kind.DescribePath(parentPath, make([]string, len(kind.GetParentQueryFlag())), data.Name.ValueString())
+	return appendQueryParams(describe.Path, queryParams), nil
+}
+
+// parentQueryParams extracts the kind's parent query params from the manifest
+// metadata, reusing ctl's Kind.ApplyPath (the same extraction Create uses).
+func parentQueryParams(kind ctlschema.Kind, manifest string) ([]ctlschema.QueryParam, error) {
+	if len(kind.GetParentQueryFlag()) == 0 || strings.TrimSpace(manifest) == "" {
+		return nil, nil
+	}
+
+	cliResources, err := ctlresource.FromYamlByte([]byte(manifest), true)
+	if err != nil {
+		return nil, err
+	}
+	if len(cliResources) == 0 {
+		return nil, nil
+	}
+
+	applyInfo, err := kind.ApplyPath(&cliResources[0])
+	if err != nil {
+		return nil, err
+	}
+	return applyInfo.QueryParams, nil
+}
+
+// appendQueryParams appends the given query parameters to the path, URL-encoded.
+func appendQueryParams(path string, params []ctlschema.QueryParam) string {
+	if len(params) == 0 {
+		return path
+	}
+	values := url.Values{}
+	for _, param := range params {
+		values.Add(param.Name, param.Value)
+	}
+	return path + "?" + values.Encode()
+}
+
+// reconcileManifest overlays the API manifest onto the prior one, returning YAML
+// that keeps only the fields the user declared. Both inputs are YAML.
+func reconcileManifest(priorManifest, apiManifest string) (string, error) {
+	var prior, api map[string]any
+	if err := yaml.Unmarshal([]byte(priorManifest), &prior); err != nil {
+		return "", err
+	}
+	if err := yaml.Unmarshal([]byte(apiManifest), &api); err != nil {
+		return "", err
+	}
+
+	out, err := yaml.Marshal(overlay(prior, api))
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// overlay keeps only the keys present in prior, taking values from api (recursing
+// into nested maps to still detect drift on declared fields). Keys missing from api
+// keep their prior value; api-only keys (server-computed) are dropped.
+func overlay(prior, api map[string]any) map[string]any {
+	result := make(map[string]any, len(prior))
+	for key, priorVal := range prior {
+		apiVal, ok := api[key]
+		if !ok {
+			result[key] = priorVal
+			continue
+		}
+		priorMap, priorIsMap := priorVal.(map[string]any)
+		apiMap, apiIsMap := apiVal.(map[string]any)
+		if priorIsMap && apiIsMap {
+			result[key] = overlay(priorMap, apiMap)
+		} else {
+			result[key] = apiVal
+		}
+	}
+	return result
 }

--- a/internal/provider/generic_resource_test.go
+++ b/internal/provider/generic_resource_test.go
@@ -42,6 +42,46 @@ func TestAccGenericResource(t *testing.T) {
 	})
 }
 
+// Alert v3 is scoped by a metadata query param (here: user), so this checks the
+// param is propagated on every verb (#186). User-scoped needs no extra fixtures.
+func TestAccGenericAlertResource(t *testing.T) {
+	resourceRef := "conduktor_generic.alert"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create + Read
+			{
+				Config: providerConfigConsole + test.TestAccTestdata(t, "generic_resource_create_alert.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceRef, "name", "test-generic-alert"),
+					resource.TestCheckResourceAttr(resourceRef, "kind", "Alert"),
+					resource.TestCheckResourceAttr(resourceRef, "version", "v3"),
+					resource.TestCheckResourceAttrWith(resourceRef, "manifest",
+						test.TestCheckResourceAttrContainsStringsFunc(
+							"\"user\": \"admin@conduktor.io\"",
+							"\"type\": \"TopicAlert\"",
+							"\"threshold\": 100",
+						)),
+				),
+			},
+			// Update + Read (threshold 100 -> 500)
+			{
+				Config: providerConfigConsole + test.TestAccTestdata(t, "generic_resource_update_alert.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceRef, "name", "test-generic-alert"),
+					resource.TestCheckResourceAttrWith(resourceRef, "manifest",
+						test.TestCheckResourceAttrContainsStringsFunc(
+							"\"user\": \"admin@conduktor.io\"",
+							"\"threshold\": 500",
+						)),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func TestAccGenericExample2Resource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },

--- a/internal/provider/generic_resource_test.go
+++ b/internal/provider/generic_resource_test.go
@@ -3,9 +3,13 @@ package provider
 import (
 	"testing"
 
+	"github.com/conduktor/terraform-provider-conduktor/internal/client"
 	"github.com/conduktor/terraform-provider-conduktor/internal/test"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+// Alert v3 was introduced in Console 1.30.
+const alertV3MinimumVersion = "v1.30.0"
 
 func TestAccGenericResource(t *testing.T) {
 	resourceRef := "conduktor_generic.embedded"
@@ -45,6 +49,12 @@ func TestAccGenericResource(t *testing.T) {
 // Alert v3 is scoped by a metadata query param (here: user), so this checks the
 // param is propagated on every verb (#186). User-scoped needs no extra fixtures.
 func TestAccGenericAlertResource(t *testing.T) {
+	v, err := fetchClientVersion(client.CONSOLE)
+	if err != nil {
+		t.Fatalf("Error fetching current version: %s", err)
+	}
+	test.CheckMinimumVersionRequirement(t, v, alertV3MinimumVersion)
+
 	resourceRef := "conduktor_generic.alert"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },

--- a/internal/provider/generic_resource_test.go
+++ b/internal/provider/generic_resource_test.go
@@ -49,6 +49,7 @@ func TestAccGenericResource(t *testing.T) {
 // Alert v3 is scoped by a metadata query param (here: user), so this checks the
 // param is propagated on every verb (#186). User-scoped needs no extra fixtures.
 func TestAccGenericAlertResource(t *testing.T) {
+	test.CheckEnterpriseEnabled(t)
 	v, err := fetchClientVersion(client.CONSOLE)
 	if err != nil {
 		t.Fatalf("Error fetching current version: %s", err)

--- a/internal/testdata/generic_resource_create_alert.tf
+++ b/internal/testdata/generic_resource_create_alert.tf
@@ -1,0 +1,27 @@
+resource "conduktor_generic" "alert" {
+  kind    = "Alert"
+  version = "v3"
+  name    = "test-generic-alert"
+  manifest = yamlencode({
+    apiVersion = "v3"
+    kind       = "Alert"
+    metadata = {
+      name = "test-generic-alert"
+      user = "admin@conduktor.io"
+    }
+    spec = {
+      type      = "TopicAlert"
+      cluster   = "kafka-cluster"
+      topicName = "my-topic"
+      metric    = "MessageCount"
+      operator  = "GreaterThan"
+      threshold = 100
+      destination = {
+        type   = "Webhook"
+        method = "POST"
+        url    = "https://example.com/hook"
+        body   = "{}"
+      }
+    }
+  })
+}

--- a/internal/testdata/generic_resource_update_alert.tf
+++ b/internal/testdata/generic_resource_update_alert.tf
@@ -1,0 +1,27 @@
+resource "conduktor_generic" "alert" {
+  kind    = "Alert"
+  version = "v3"
+  name    = "test-generic-alert"
+  manifest = yamlencode({
+    apiVersion = "v3"
+    kind       = "Alert"
+    metadata = {
+      name = "test-generic-alert"
+      user = "admin@conduktor.io"
+    }
+    spec = {
+      type      = "TopicAlert"
+      cluster   = "kafka-cluster"
+      topicName = "my-topic"
+      metric    = "MessageCount"
+      operator  = "GreaterThan"
+      threshold = 500
+      destination = {
+        type   = "Webhook"
+        method = "POST"
+        url    = "https://example.com/hook"
+        body   = "{}"
+      }
+    }
+  })
+}


### PR DESCRIPTION
Fix generic resource compatibility for #186 
- Added missing query parameters on Apply/Read/Delete resource url. 
- Added YAML manifest reconciliation on resource Read result to discard server side fields in order to avoid dirty plan. 
- Added a new Generic resource test with Alert v3 resources that is not yet supported by the provider.