### PR TITLE
fix: remove double /api prefix in GetConsoleLicensePlan

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -356,7 +356,7 @@ func (client *Client) GetConsoleLicensePlan(ctx context.Context) (string, error)
 	} else if orgsResp.IsError() {
 		return "", fmt.Errorf("error fetching organizations: %s", ExtractApiError(orgsResp))
 	}
-	tflog.Trace(ctx, fmt.Sprintf("GET /organizations response : %s", string(orgsResp.Body())))
+	tflog.Trace(ctx, fmt.Sprintf("GET /api/organizations response : %s", string(orgsResp.Body())))
 
 	var orgs []map[string]any
 	err = json.Unmarshal(orgsResp.Body(), &orgs)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -349,14 +349,14 @@ func (client *Client) GetAPIVersion(ctx context.Context, mode Mode) (string, err
 // then fetches the license info from GET /api/organizations/{slug}/platform-license.
 func (client *Client) GetConsoleLicensePlan(ctx context.Context) (string, error) {
 	// Get the default organization slug
-	orgsURL := client.BaseUrl + "/api/organizations"
+	orgsURL := client.BaseUrl + "/organizations"
 	orgsResp, err := client.Client.R().Get(orgsURL)
 	if err != nil {
 		return "", fmt.Errorf("error fetching organizations: %s", err)
 	} else if orgsResp.IsError() {
 		return "", fmt.Errorf("error fetching organizations: %s", ExtractApiError(orgsResp))
 	}
-	tflog.Trace(ctx, fmt.Sprintf("GET /api/organizations response : %s", string(orgsResp.Body())))
+	tflog.Trace(ctx, fmt.Sprintf("GET /organizations response : %s", string(orgsResp.Body())))
 
 	var orgs []map[string]any
 	err = json.Unmarshal(orgsResp.Body(), &orgs)
@@ -373,7 +373,7 @@ func (client *Client) GetConsoleLicensePlan(ctx context.Context) (string, error)
 	}
 
 	// Fetch the license info for the organization
-	licensePath := fmt.Sprintf("/api/organizations/%s/platform-license", slug)
+	licensePath := fmt.Sprintf("/organizations/%s/platform-license", slug)
 	licenseURL := client.BaseUrl + licensePath
 	licenseResp, err := client.Client.R().Get(licenseURL)
 	if err != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -345,8 +345,8 @@ func (client *Client) GetAPIVersion(ctx context.Context, mode Mode) (string, err
 }
 
 // GetConsoleLicensePlan returns the Console license plan ("free" or "enterprise").
-// It first fetches the default org slug from GET /api/organizations,
-// then fetches the license info from GET /api/organizations/{slug}/platform-license.
+// It first fetches the default org slug from GET /organizations,
+// then fetches the license info from GET /organizations/{slug}/platform-license.
 func (client *Client) GetConsoleLicensePlan(ctx context.Context) (string, error) {
 	// Get the default organization slug
 	orgsURL := client.BaseUrl + "/organizations"

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -19,15 +19,15 @@ func TestGetConsoleLicensePlan_NoDoubleApiPrefix(t *testing.T) {
 		case "/api/organizations":
 			orgsHit = true
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode([]map[string]any{{"slug": "my-org"}})
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"slug": "my-org"}})
 		case "/api/organizations/my-org/platform-license":
 			licenseHit = true
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"plan": "enterprise"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"plan": "enterprise"})
 		default:
 			// Return HTML like Console SPA does for unmatched routes — this is what triggers the bug
 			w.Header().Set("Content-Type", "text/html")
-			w.Write([]byte("<html>not found</html>"))
+			_, _ = w.Write([]byte("<html>not found</html>"))
 		}
 	}))
 	defer ts.Close()

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+)
+
+func TestGetConsoleLicensePlan_NoDoubleApiPrefix(t *testing.T) {
+	orgsHit := false
+	licenseHit := false
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/organizations":
+			orgsHit = true
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{{"slug": "my-org"}})
+		case "/api/organizations/my-org/platform-license":
+			licenseHit = true
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"plan": "enterprise"})
+		default:
+			// Return HTML like Console SPA does for unmatched routes — this is what triggers the bug
+			w.Header().Set("Content-Type", "text/html")
+			w.Write([]byte("<html>not found</html>"))
+		}
+	}))
+	defer ts.Close()
+
+	c := &Client{
+		BaseUrl: ts.URL + "/api",
+		Client:  resty.New(),
+	}
+
+	plan, err := c.GetConsoleLicensePlan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan != "enterprise" {
+		t.Errorf("expected plan 'enterprise', got %q", plan)
+	}
+	if !orgsHit {
+		t.Error("GET /api/organizations was never called — double /api prefix likely")
+	}
+	if !licenseHit {
+		t.Error("GET /api/organizations/my-org/platform-license was never called — double /api prefix likely")
+	}
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/go-resty/resty/v2"
 )
 
 func TestGetConsoleLicensePlan_NoDoubleApiPrefix(t *testing.T) {
@@ -32,9 +30,14 @@ func TestGetConsoleLicensePlan_NoDoubleApiPrefix(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := &Client{
-		BaseUrl: ts.URL + "/api",
-		Client:  resty.New(),
+	// Use Make so uniformizeBaseUrl is in the callstack — it appends /api to the base URL,
+	// which is the real production path. Passing ts.URL (no /api) verifies the fix end-to-end.
+	c, err := Make(context.Background(), CONSOLE, ApiParameter{
+		BaseUrl: ts.URL,
+		ApiKey:  "test-key",
+	}, "test")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
 	}
 
 	plan, err := c.GetConsoleLicensePlan(context.Background())
@@ -49,5 +52,23 @@ func TestGetConsoleLicensePlan_NoDoubleApiPrefix(t *testing.T) {
 	}
 	if !licenseHit {
 		t.Error("GET /api/organizations/my-org/platform-license was never called — double /api prefix likely")
+	}
+}
+
+func TestUniformizeBaseUrl(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"https://console.example.com", "https://console.example.com/api"},
+		{"https://console.example.com/", "https://console.example.com/api"},
+		{"https://console.example.com/api", "https://console.example.com/api"},
+		{"https://console.example.com/api/", "https://console.example.com/api"},
+	}
+	for _, tc := range cases {
+		got := uniformizeBaseUrl(tc.input)
+		if got != tc.expected {
+			t.Errorf("uniformizeBaseUrl(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- `GetConsoleLicensePlan` was constructing URLs with a double `/api` prefix (`/api/api/organizations`) because `client.BaseUrl` already ends in `/api` (enforced by `uniformizeBaseUrl`)
- This caused the request to hit no Console route, returning the SPA's `index.html` (HTTP 200, HTML body), which then failed JSON parsing with `invalid character '<'`
- Result: spurious "Unable to check Console license plan" warning on every `terraform plan`/`apply` for 6 resource types that call `checkEnterprisePlanRequirement`

## Changes

- `internal/client/client.go`: removed `/api` prefix from two path strings in `GetConsoleLicensePlan` (lines 352 and 376)
- `internal/client/client_test.go`: added unit test using `httptest.Server` that simulates Console's SPA fallback behaviour and asserts both correct URL paths are hit

## Test plan

- [ ] `go test ./internal/client/... -v` passes
- [ ] `go build ./...` clean
- [ ] Manual: `terraform plan` against a live Console instance no longer emits "Unable to check Console license plan" warnings for `conduktor_console_application_v1` and related resources

Fixes: https://linear.app/conduktor/issue/CUS-991