### PR TITLE
Added field instancePermissions to console_application_group_v1

### DIFF
--- a/docs/resources/console_application_group_v1.md
+++ b/docs/resources/console_application_group_v1.md
@@ -96,12 +96,25 @@ Optional:
 - `description` (String) Description of the application group
 - `external_group_regex` (Set of String) Set of regex to be applied to external groups. NOTE: this field has been introduced with Console `1.36.0` and it will not work with previous versions
 - `external_groups` (Set of String) Set of external groups from SSO mapped to this group
+- `instance_permissions` (Attributes Set) Set of instance-level permissions granted to this group on application instances (see [below for nested schema](#nestedatt--spec--instance_permissions))
 - `members` (Set of String) Set of members of the group
 - `permissions` (Attributes Set) Set of all group permissions (see [below for nested schema](#nestedatt--spec--permissions))
 
 Read-Only:
 
 - `members_from_external_groups` (Set of String) Set of members of the group (managed by backend, ReadOnly in Terraform)
+
+<a id="nestedatt--spec--instance_permissions"></a>
+### Nested Schema for `spec.instance_permissions`
+
+Required:
+
+- `app_instance` (String) Reference to the application instance
+
+Optional:
+
+- `permissions` (Set of String) Set of instance-level permissions to grant. Valid values are: applicationInstancePermissionRequestAccess, applicationInstancePermissionGrantAccess, applicationInstanceApiKeyManage, applicationInstancePermissionProposeAccess, serviceAccountManage
+
 
 <a id="nestedatt--spec--permissions"></a>
 ### Nested Schema for `spec.permissions`

--- a/internal/mapper/console_application_group_v1/console_application_group_v1_resource_mapper.go
+++ b/internal/mapper/console_application_group_v1/console_application_group_v1_resource_mapper.go
@@ -43,6 +43,12 @@ func TFToInternalModel(ctx context.Context, r *appgroup.ConsoleApplicationGroupV
 		return console.ApplicationGroupConsoleResource{}, err
 	}
 
+	// InstancePermissions
+	instancePermissions, err := SetValueToApplicationGroupInstancePermissionArray(ctx, r.Spec.InstancePermissions)
+	if err != nil {
+		return console.ApplicationGroupConsoleResource{}, err
+	}
+
 	return console.NewApplicationGroupConsoleResource(
 		r.Name.ValueString(),
 		r.Application.ValueString(),
@@ -54,6 +60,7 @@ func TFToInternalModel(ctx context.Context, r *appgroup.ConsoleApplicationGroupV
 			Members:                   members,
 			MembersFromExternalGroups: membersFromExternalGroups,
 			Permissions:               permissions,
+			InstancePermissions:       instancePermissions,
 		},
 	), nil
 
@@ -85,6 +92,11 @@ func InternalModelToTerraform(ctx context.Context, r *console.ApplicationGroupCo
 		return appgroup.ConsoleApplicationGroupV1Model{}, err
 	}
 
+	instancePermissionsList, err := ApplicationGroupInstancePermissionArrayToSetValue(ctx, r.Spec.InstancePermissions)
+	if err != nil {
+		return appgroup.ConsoleApplicationGroupV1Model{}, err
+	}
+
 	specValue, diag := appgroup.NewSpecValue(
 		map[string]attr.Type{
 			"description":                  basetypes.StringType{},
@@ -94,6 +106,7 @@ func InternalModelToTerraform(ctx context.Context, r *console.ApplicationGroupCo
 			"members":                      membersList.Type(ctx),
 			"members_from_external_groups": membersFromExternalGroupsList.Type(ctx),
 			"permissions":                  permissionsList.Type(ctx),
+			"instance_permissions":         instancePermissionsList.Type(ctx),
 		},
 		map[string]attr.Value{
 			"description":                  schema.NewStringValue(r.Spec.Description),
@@ -103,6 +116,7 @@ func InternalModelToTerraform(ctx context.Context, r *console.ApplicationGroupCo
 			"members":                      membersList,
 			"members_from_external_groups": membersFromExternalGroupsList,
 			"permissions":                  permissionsList,
+			"instance_permissions":         instancePermissionsList,
 		},
 	)
 	if diag.HasError() {
@@ -188,4 +202,65 @@ func SetValueToApplicationGroupPermissionArray(ctx context.Context, set basetype
 		}
 	}
 	return permission, nil
+}
+
+// Parse an ApplicationGroupInstancePermissions Array into a Set.
+func ApplicationGroupInstancePermissionArrayToSetValue(ctx context.Context, arr []console.ApplicationGroupInstancePermission) (basetypes.SetValue, error) {
+	var tfInstancePermissions []attr.Value
+	var diag diag.Diagnostics
+
+	for _, p := range arr {
+		flagsList, diag := schema.StringArrayToSetValue(p.Permissions)
+		if diag.HasError() {
+			return basetypes.SetValue{}, mapper.WrapDiagError(diag, "instance_permissions.permissions", mapper.IntoTerraform)
+		}
+
+		attrTypes := map[string]attr.Type{
+			"app_instance": basetypes.StringType{},
+			"permissions":  flagsList.Type(ctx),
+		}
+		attrValues := map[string]attr.Value{
+			"app_instance": schema.NewStringValue(p.AppInstance),
+			"permissions":  flagsList,
+		}
+
+		instancePermObj, diag := appgroup.NewInstancePermissionsValue(attrTypes, attrValues)
+		if diag.HasError() {
+			return basetypes.SetValue{}, mapper.WrapDiagError(diag, "instance_permissions", mapper.IntoTerraform)
+		}
+		tfInstancePermissions = append(tfInstancePermissions, instancePermObj)
+	}
+
+	instancePermissionsList, diag := types.SetValue(appgroup.InstancePermissionsValue{}.Type(ctx), tfInstancePermissions)
+	if diag.HasError() {
+		return basetypes.SetValue{}, mapper.WrapDiagError(diag, "instance_permissions", mapper.IntoTerraform)
+	}
+
+	return instancePermissionsList, nil
+}
+
+// Parse a Set into an array of ApplicationGroupInstancePermissions.
+func SetValueToApplicationGroupInstancePermissionArray(ctx context.Context, set basetypes.SetValue) ([]console.ApplicationGroupInstancePermission, error) {
+	instancePermissions := make([]console.ApplicationGroupInstancePermission, 0)
+	var diag diag.Diagnostics
+
+	if !set.IsNull() && !set.IsUnknown() {
+		var tfInstancePermissions []appgroup.InstancePermissionsValue
+		diag = set.ElementsAs(ctx, &tfInstancePermissions, false)
+		if diag.HasError() {
+			return nil, mapper.WrapDiagError(diag, "instance_permissions", mapper.FromTerraform)
+		}
+		for _, p := range tfInstancePermissions {
+			flags, diag := schema.SetValueToStringArray(ctx, p.Permissions)
+			if diag.HasError() {
+				return nil, mapper.WrapDiagError(diag, "instance_permissions.permissions", mapper.FromTerraform)
+			}
+
+			instancePermissions = append(instancePermissions, console.ApplicationGroupInstancePermission{
+				AppInstance: p.AppInstance.ValueString(),
+				Permissions: flags,
+			})
+		}
+	}
+	return instancePermissions, nil
 }

--- a/internal/mapper/console_application_group_v1/console_application_group_v1_resource_mapper_test.go
+++ b/internal/mapper/console_application_group_v1/console_application_group_v1_resource_mapper_test.go
@@ -71,6 +71,14 @@ func TestApplicationGroupV1ModelMapping(t *testing.T) {
 	}
 	assert.Equal(t, expectedInternalResources, internal.Spec.Permissions)
 
+	expectedInstancePermissions := []console.ApplicationGroupInstancePermission{
+		{
+			AppInstance: "test-application-dev",
+			Permissions: []string{"applicationInstanceApiKeyManage", "applicationInstancePermissionGrantAccess"},
+		},
+	}
+	assert.Equal(t, expectedInstancePermissions, internal.Spec.InstancePermissions)
+
 	// convert to terraform model
 	tfModel, err := InternalModelToTerraform(ctx, &internal)
 	if err != nil {
@@ -105,6 +113,7 @@ func TestApplicationGroupV1ModelMapping(t *testing.T) {
 	assert.Equal(t, []string{".*"}, internal2.Spec.ExternalGroupRegex)
 	assert.Equal(t, []string{"tatum@conduktor.io"}, internal2.Spec.Members)
 	assert.Equal(t, expectedInternalResources, internal2.Spec.Permissions)
+	assert.Equal(t, expectedInstancePermissions, internal2.Spec.InstancePermissions)
 	assert.Equal(t, internal, internal2)
 
 	// convert back to ctl model

--- a/internal/model/console/application_group_v1.go
+++ b/internal/model/console/application_group_v1.go
@@ -32,7 +32,7 @@ type ApplicationGroupPermission struct {
 
 type ApplicationGroupInstancePermission struct {
 	AppInstance string   `json:"appInstance"`
-	Permissions []string `json:"permissions"`
+	Permissions []string `json:"permissions,omitempty"`
 }
 
 type ApplicationGroupSpec struct {

--- a/internal/model/console/application_group_v1.go
+++ b/internal/model/console/application_group_v1.go
@@ -30,14 +30,20 @@ type ApplicationGroupPermission struct {
 	Permissions    []string `json:"permissions"`
 }
 
+type ApplicationGroupInstancePermission struct {
+	AppInstance string   `json:"appInstance"`
+	Permissions []string `json:"permissions"`
+}
+
 type ApplicationGroupSpec struct {
-	DisplayName               string                       `json:"displayName"`
-	Description               string                       `json:"description,omitempty"`
-	Permissions               []ApplicationGroupPermission `json:"permissions"`
-	Members                   []string                     `json:"members"`
-	ExternalGroups            []string                     `json:"externalGroups"`
-	ExternalGroupRegex        []string                     `json:"externalGroupRegex,omitempty"`
-	MembersFromExternalGroups []string                     `json:"membersFromExternalGroups"`
+	DisplayName               string                               `json:"displayName"`
+	Description               string                               `json:"description,omitempty"`
+	Permissions               []ApplicationGroupPermission         `json:"permissions"`
+	InstancePermissions       []ApplicationGroupInstancePermission `json:"instancePermissions,omitempty"`
+	Members                   []string                             `json:"members"`
+	ExternalGroups            []string                             `json:"externalGroups"`
+	ExternalGroupRegex        []string                             `json:"externalGroupRegex,omitempty"`
+	MembersFromExternalGroups []string                             `json:"membersFromExternalGroups"`
 }
 
 type ApplicationGroupConsoleResource struct {

--- a/internal/provider/console_application_group_v1_resource.go
+++ b/internal/provider/console_application_group_v1_resource.go
@@ -16,6 +16,7 @@ import (
 
 const applicationGroupV1ApiPath = "/public/self-serve/v1/application-group"
 const applicationGroupV1EnterpriseOnlyVersion = "v1.43.0"
+const applicationGroupV1InstancePermissionsMinVersion = "v1.44.0"
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &ApplicationGroupV1Resource{}

--- a/internal/provider/console_application_group_v1_resource_test.go
+++ b/internal/provider/console_application_group_v1_resource_test.go
@@ -32,6 +32,10 @@ func TestAccApplicationGroupV1Resource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceRef, "spec.permissions.0.name", "*"),
 					resource.TestCheckResourceAttr(resourceRef, "spec.permissions.0.permissions.#", "1"),
 					resource.TestCheckResourceAttr(resourceRef, "spec.permissions.0.permissions.0", "topicViewConfig"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.instance_permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.instance_permissions.0.app_instance", "my-app-instance"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.instance_permissions.0.permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.instance_permissions.0.permissions.0", "applicationInstancePermissionGrantAccess"),
 				),
 			},
 			// Importing matches the state of the previous step.

--- a/internal/provider/console_application_group_v1_resource_test.go
+++ b/internal/provider/console_application_group_v1_resource_test.go
@@ -3,21 +3,48 @@ package provider
 import (
 	"testing"
 
+	"github.com/conduktor/terraform-provider-conduktor/internal/client"
 	"github.com/conduktor/terraform-provider-conduktor/internal/test"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"golang.org/x/mod/semver"
 )
 
 func TestAccApplicationGroupV1Resource(t *testing.T) {
 	test.CheckEnterpriseEnabled(t)
+	v, err := fetchClientVersion(client.CONSOLE)
+	if err != nil {
+		t.Fatalf("Error fetching current version: %s", err)
+	}
+	instancePermissionsSupported := !semver.IsValid(v) || semver.Compare(v, applicationGroupV1InstancePermissionsMinVersion) >= 0
 	resourceRef := "conduktor_console_application_group_v1.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create and Read testing
+			// Create and Read testing (without instance_permissions for pre-v1.44.0 compatibility)
 			{
-				Config: providerConfigConsole + test.TestAccTestdata(t, "console/application_group_v1/resource_create.tf"),
+				Config: providerConfigConsole + test.TestAccTestdata(t, "console/application_group_v1/resource_create_no_instance_permissions.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceRef, "name", "myappgroup"),
+					resource.TestCheckResourceAttr(resourceRef, "application", "myapp"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.display_name", "My Application Group"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.description", "test"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.external_groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.external_groups.0", "mygroup"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.permissions.0.app_instance", "my-app-instance"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.permissions.0.resource_type", "TOPIC"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.permissions.0.pattern_type", "LITERAL"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.permissions.0.name", "*"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.permissions.0.permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceRef, "spec.permissions.0.permissions.0", "topicViewConfig"),
+				),
+			},
+			// Create and Read testing with instance_permissions (v1.44.0+)
+			{
+				SkipFunc: func() (bool, error) { return !instancePermissionsSupported, nil },
+				Config:   providerConfigConsole + test.TestAccTestdata(t, "console/application_group_v1/resource_create.tf"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceRef, "name", "myappgroup"),
 					resource.TestCheckResourceAttr(resourceRef, "application", "myapp"),

--- a/internal/schema/resource_console_application_group_v1/console_application_group_v1_resource_gen.go
+++ b/internal/schema/resource_console_application_group_v1/console_application_group_v1_resource_gen.go
@@ -74,6 +74,38 @@ func ConsoleApplicationGroupV1ResourceSchema(ctx context.Context) schema.Schema 
 						MarkdownDescription: "Set of external groups from SSO mapped to this group",
 						Default:             setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{})),
 					},
+					"instance_permissions": schema.SetNestedAttribute{
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"app_instance": schema.StringAttribute{
+									Required:            true,
+									Description:         "Reference to the application instance",
+									MarkdownDescription: "Reference to the application instance",
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+									},
+								},
+								"permissions": schema.SetAttribute{
+									ElementType:         types.StringType,
+									Optional:            true,
+									Description:         "Set of instance-level permissions to grant. Valid values are: applicationInstancePermissionRequestAccess, applicationInstancePermissionGrantAccess, applicationInstanceApiKeyManage, applicationInstancePermissionProposeAccess, serviceAccountManage",
+									MarkdownDescription: "Set of instance-level permissions to grant. Valid values are: applicationInstancePermissionRequestAccess, applicationInstancePermissionGrantAccess, applicationInstanceApiKeyManage, applicationInstancePermissionProposeAccess, serviceAccountManage",
+									Validators: []validator.Set{
+										setvalidator.ValueStringsAre(stringvalidator.OneOf(validation.ValidAppGroupInstancePermissions...)),
+									},
+								},
+							},
+							CustomType: InstancePermissionsType{
+								ObjectType: types.ObjectType{
+									AttrTypes: InstancePermissionsValue{}.AttributeTypes(ctx),
+								},
+							},
+						},
+						Optional:            true,
+						Computed:            true,
+						Description:         "Set of instance-level permissions granted to this group on application instances",
+						MarkdownDescription: "Set of instance-level permissions granted to this group on application instances",
+					},
 					"members": schema.SetAttribute{
 						ElementType:         types.StringType,
 						Optional:            true,
@@ -267,6 +299,24 @@ func (t SpecType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 			fmt.Sprintf(`external_groups expected to be basetypes.SetValue, was: %T`, externalGroupsAttribute))
 	}
 
+	instancePermissionsAttribute, ok := attributes["instance_permissions"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`instance_permissions is missing from object`)
+
+		return nil, diags
+	}
+
+	instancePermissionsVal, ok := instancePermissionsAttribute.(basetypes.SetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`instance_permissions expected to be basetypes.SetValue, was: %T`, instancePermissionsAttribute))
+	}
+
 	membersAttribute, ok := attributes["members"]
 
 	if !ok {
@@ -330,6 +380,7 @@ func (t SpecType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 		DisplayName:               displayNameVal,
 		ExternalGroupRegex:        externalGroupRegexVal,
 		ExternalGroups:            externalGroupsVal,
+		InstancePermissions:       instancePermissionsVal,
 		Members:                   membersVal,
 		MembersFromExternalGroups: membersFromExternalGroupsVal,
 		Permissions:               permissionsVal,
@@ -472,6 +523,24 @@ func NewSpecValue(attributeTypes map[string]attr.Type, attributes map[string]att
 			fmt.Sprintf(`external_groups expected to be basetypes.SetValue, was: %T`, externalGroupsAttribute))
 	}
 
+	instancePermissionsAttribute, ok := attributes["instance_permissions"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`instance_permissions is missing from object`)
+
+		return NewSpecValueUnknown(), diags
+	}
+
+	instancePermissionsVal, ok := instancePermissionsAttribute.(basetypes.SetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`instance_permissions expected to be basetypes.SetValue, was: %T`, instancePermissionsAttribute))
+	}
+
 	membersAttribute, ok := attributes["members"]
 
 	if !ok {
@@ -535,6 +604,7 @@ func NewSpecValue(attributeTypes map[string]attr.Type, attributes map[string]att
 		DisplayName:               displayNameVal,
 		ExternalGroupRegex:        externalGroupRegexVal,
 		ExternalGroups:            externalGroupsVal,
+		InstancePermissions:       instancePermissionsVal,
 		Members:                   membersVal,
 		MembersFromExternalGroups: membersFromExternalGroupsVal,
 		Permissions:               permissionsVal,
@@ -614,6 +684,7 @@ type SpecValue struct {
 	DisplayName               basetypes.StringValue `tfsdk:"display_name"`
 	ExternalGroupRegex        basetypes.SetValue    `tfsdk:"external_group_regex"`
 	ExternalGroups            basetypes.SetValue    `tfsdk:"external_groups"`
+	InstancePermissions       basetypes.SetValue    `tfsdk:"instance_permissions"`
 	Members                   basetypes.SetValue    `tfsdk:"members"`
 	MembersFromExternalGroups basetypes.SetValue    `tfsdk:"members_from_external_groups"`
 	Permissions               basetypes.SetValue    `tfsdk:"permissions"`
@@ -621,7 +692,7 @@ type SpecValue struct {
 }
 
 func (v SpecValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 7)
+	attrTypes := make(map[string]tftypes.Type, 8)
 
 	var val tftypes.Value
 	var err error
@@ -633,6 +704,9 @@ func (v SpecValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) 
 	}.TerraformType(ctx)
 	attrTypes["external_groups"] = basetypes.SetType{
 		ElemType: types.StringType,
+	}.TerraformType(ctx)
+	attrTypes["instance_permissions"] = basetypes.SetType{
+		ElemType: InstancePermissionsValue{}.Type(ctx),
 	}.TerraformType(ctx)
 	attrTypes["members"] = basetypes.SetType{
 		ElemType: types.StringType,
@@ -648,7 +722,7 @@ func (v SpecValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) 
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 7)
+		vals := make(map[string]tftypes.Value, 8)
 
 		val, err = v.Description.ToTerraformValue(ctx)
 
@@ -681,6 +755,14 @@ func (v SpecValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) 
 		}
 
 		vals["external_groups"] = val
+
+		val, err = v.InstancePermissions.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["instance_permissions"] = val
 
 		val, err = v.Members.ToTerraformValue(ctx)
 
@@ -735,6 +817,35 @@ func (v SpecValue) String() string {
 func (v SpecValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	instancePermissions := types.SetValueMust(
+		InstancePermissionsType{
+			basetypes.ObjectType{
+				AttrTypes: InstancePermissionsValue{}.AttributeTypes(ctx),
+			},
+		},
+		v.InstancePermissions.Elements(),
+	)
+
+	if v.InstancePermissions.IsNull() {
+		instancePermissions = types.SetNull(
+			InstancePermissionsType{
+				basetypes.ObjectType{
+					AttrTypes: InstancePermissionsValue{}.AttributeTypes(ctx),
+				},
+			},
+		)
+	}
+
+	if v.InstancePermissions.IsUnknown() {
+		instancePermissions = types.SetUnknown(
+			InstancePermissionsType{
+				basetypes.ObjectType{
+					AttrTypes: InstancePermissionsValue{}.AttributeTypes(ctx),
+				},
+			},
+		)
+	}
+
 	permissions := types.SetValueMust(
 		PermissionsType{
 			basetypes.ObjectType{
@@ -786,6 +897,9 @@ func (v SpecValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, di
 			"external_groups": basetypes.SetType{
 				ElemType: types.StringType,
 			},
+			"instance_permissions": basetypes.SetType{
+				ElemType: InstancePermissionsValue{}.Type(ctx),
+			},
 			"members": basetypes.SetType{
 				ElemType: types.StringType,
 			},
@@ -819,6 +933,9 @@ func (v SpecValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, di
 			},
 			"external_groups": basetypes.SetType{
 				ElemType: types.StringType,
+			},
+			"instance_permissions": basetypes.SetType{
+				ElemType: InstancePermissionsValue{}.Type(ctx),
 			},
 			"members": basetypes.SetType{
 				ElemType: types.StringType,
@@ -854,6 +971,9 @@ func (v SpecValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, di
 			"external_groups": basetypes.SetType{
 				ElemType: types.StringType,
 			},
+			"instance_permissions": basetypes.SetType{
+				ElemType: InstancePermissionsValue{}.Type(ctx),
+			},
 			"members": basetypes.SetType{
 				ElemType: types.StringType,
 			},
@@ -888,6 +1008,9 @@ func (v SpecValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, di
 			"external_groups": basetypes.SetType{
 				ElemType: types.StringType,
 			},
+			"instance_permissions": basetypes.SetType{
+				ElemType: InstancePermissionsValue{}.Type(ctx),
+			},
 			"members": basetypes.SetType{
 				ElemType: types.StringType,
 			},
@@ -908,6 +1031,9 @@ func (v SpecValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, di
 		},
 		"external_groups": basetypes.SetType{
 			ElemType: types.StringType,
+		},
+		"instance_permissions": basetypes.SetType{
+			ElemType: InstancePermissionsValue{}.Type(ctx),
 		},
 		"members": basetypes.SetType{
 			ElemType: types.StringType,
@@ -935,6 +1061,7 @@ func (v SpecValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, di
 			"display_name":                 v.DisplayName,
 			"external_group_regex":         externalGroupRegexVal,
 			"external_groups":              externalGroupsVal,
+			"instance_permissions":         instancePermissions,
 			"members":                      membersVal,
 			"members_from_external_groups": membersFromExternalGroupsVal,
 			"permissions":                  permissions,
@@ -974,6 +1101,10 @@ func (v SpecValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.InstancePermissions.Equal(other.InstancePermissions) {
+		return false
+	}
+
 	if !v.Members.Equal(other.Members) {
 		return false
 	}
@@ -1007,6 +1138,9 @@ func (v SpecValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		"external_groups": basetypes.SetType{
 			ElemType: types.StringType,
 		},
+		"instance_permissions": basetypes.SetType{
+			ElemType: InstancePermissionsValue{}.Type(ctx),
+		},
 		"members": basetypes.SetType{
 			ElemType: types.StringType,
 		},
@@ -1015,6 +1149,412 @@ func (v SpecValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		},
 		"permissions": basetypes.SetType{
 			ElemType: PermissionsValue{}.Type(ctx),
+		},
+	}
+}
+
+var _ basetypes.ObjectTypable = InstancePermissionsType{}
+
+type InstancePermissionsType struct {
+	basetypes.ObjectType
+}
+
+func (t InstancePermissionsType) Equal(o attr.Type) bool {
+	other, ok := o.(InstancePermissionsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t InstancePermissionsType) String() string {
+	return "InstancePermissionsType"
+}
+
+func (t InstancePermissionsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	appInstanceAttribute, ok := attributes["app_instance"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`app_instance is missing from object`)
+
+		return nil, diags
+	}
+
+	appInstanceVal, ok := appInstanceAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`app_instance expected to be basetypes.StringValue, was: %T`, appInstanceAttribute))
+	}
+
+	permissionsAttribute, ok := attributes["permissions"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`permissions is missing from object`)
+
+		return nil, diags
+	}
+
+	permissionsVal, ok := permissionsAttribute.(basetypes.SetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`permissions expected to be basetypes.SetValue, was: %T`, permissionsAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return InstancePermissionsValue{
+		AppInstance: appInstanceVal,
+		Permissions: permissionsVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewInstancePermissionsValueNull() InstancePermissionsValue {
+	return InstancePermissionsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewInstancePermissionsValueUnknown() InstancePermissionsValue {
+	return InstancePermissionsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewInstancePermissionsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (InstancePermissionsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing InstancePermissionsValue Attribute Value",
+				"While creating a InstancePermissionsValue value, a missing attribute value was detected. "+
+					"A InstancePermissionsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("InstancePermissionsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid InstancePermissionsValue Attribute Type",
+				"While creating a InstancePermissionsValue value, an invalid attribute value was detected. "+
+					"A InstancePermissionsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("InstancePermissionsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("InstancePermissionsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra InstancePermissionsValue Attribute Value",
+				"While creating a InstancePermissionsValue value, an extra attribute value was detected. "+
+					"A InstancePermissionsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra InstancePermissionsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewInstancePermissionsValueUnknown(), diags
+	}
+
+	appInstanceAttribute, ok := attributes["app_instance"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`app_instance is missing from object`)
+
+		return NewInstancePermissionsValueUnknown(), diags
+	}
+
+	appInstanceVal, ok := appInstanceAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`app_instance expected to be basetypes.StringValue, was: %T`, appInstanceAttribute))
+	}
+
+	permissionsAttribute, ok := attributes["permissions"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`permissions is missing from object`)
+
+		return NewInstancePermissionsValueUnknown(), diags
+	}
+
+	permissionsVal, ok := permissionsAttribute.(basetypes.SetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`permissions expected to be basetypes.SetValue, was: %T`, permissionsAttribute))
+	}
+
+	if diags.HasError() {
+		return NewInstancePermissionsValueUnknown(), diags
+	}
+
+	return InstancePermissionsValue{
+		AppInstance: appInstanceVal,
+		Permissions: permissionsVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewInstancePermissionsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) InstancePermissionsValue {
+	object, diags := NewInstancePermissionsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewInstancePermissionsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t InstancePermissionsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewInstancePermissionsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewInstancePermissionsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewInstancePermissionsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewInstancePermissionsValueMust(InstancePermissionsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t InstancePermissionsType) ValueType(ctx context.Context) attr.Value {
+	return InstancePermissionsValue{}
+}
+
+var _ basetypes.ObjectValuable = InstancePermissionsValue{}
+
+type InstancePermissionsValue struct {
+	AppInstance basetypes.StringValue `tfsdk:"app_instance"`
+	Permissions basetypes.SetValue    `tfsdk:"permissions"`
+	state       attr.ValueState
+}
+
+func (v InstancePermissionsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["app_instance"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["permissions"] = basetypes.SetType{
+		ElemType: types.StringType,
+	}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.AppInstance.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["app_instance"] = val
+
+		val, err = v.Permissions.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["permissions"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v InstancePermissionsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v InstancePermissionsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v InstancePermissionsValue) String() string {
+	return "InstancePermissionsValue"
+}
+
+func (v InstancePermissionsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var permissionsVal basetypes.SetValue
+	switch {
+	case v.Permissions.IsUnknown():
+		permissionsVal = types.SetUnknown(types.StringType)
+	case v.Permissions.IsNull():
+		permissionsVal = types.SetNull(types.StringType)
+	default:
+		var d diag.Diagnostics
+		permissionsVal, d = types.SetValue(types.StringType, v.Permissions.Elements())
+		diags.Append(d...)
+	}
+
+	if diags.HasError() {
+		return types.ObjectUnknown(map[string]attr.Type{
+			"app_instance": basetypes.StringType{},
+			"permissions": basetypes.SetType{
+				ElemType: types.StringType,
+			},
+		}), diags
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"app_instance": basetypes.StringType{},
+		"permissions": basetypes.SetType{
+			ElemType: types.StringType,
+		},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"app_instance": v.AppInstance,
+			"permissions":  permissionsVal,
+		})
+
+	return objVal, diags
+}
+
+func (v InstancePermissionsValue) Equal(o attr.Value) bool {
+	other, ok := o.(InstancePermissionsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AppInstance.Equal(other.AppInstance) {
+		return false
+	}
+
+	if !v.Permissions.Equal(other.Permissions) {
+		return false
+	}
+
+	return true
+}
+
+func (v InstancePermissionsValue) Type(ctx context.Context) attr.Type {
+	return InstancePermissionsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v InstancePermissionsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"app_instance": basetypes.StringType{},
+		"permissions": basetypes.SetType{
+			ElemType: types.StringType,
 		},
 	}
 }

--- a/internal/schema/validation/schema_validation.go
+++ b/internal/schema/validation/schema_validation.go
@@ -71,6 +71,14 @@ var ValidAppGroupPermissions = []string{
 	"topicDataQualityManage",
 }
 
+var ValidAppGroupInstancePermissions = []string{
+	"applicationInstancePermissionRequestAccess",
+	"applicationInstancePermissionGrantAccess",
+	"applicationInstanceApiKeyManage",
+	"applicationInstancePermissionProposeAccess",
+	"serviceAccountManage",
+}
+
 // Provider modes.
 var ValidProviderMode = []string{"console", "gateway"}
 

--- a/internal/testdata/console/application_group_v1/api.json
+++ b/internal/testdata/console/application_group_v1/api.json
@@ -45,6 +45,15 @@
         "resourceType": "TOPIC"
       }
     ],
+    "instancePermissions": [
+      {
+        "appInstance": "test-application-dev",
+        "permissions": [
+          "applicationInstanceApiKeyManage",
+          "applicationInstancePermissionGrantAccess"
+        ]
+      }
+    ],
     "members": [
       "tatum@conduktor.io"
     ],

--- a/internal/testdata/console/application_group_v1/resource_create.tf
+++ b/internal/testdata/console/application_group_v1/resource_create.tf
@@ -15,5 +15,11 @@ resource "conduktor_console_application_group_v1" "test" {
         permissions   = ["topicViewConfig"]
       },
     ]
+    instance_permissions = [
+      {
+        app_instance = "my-app-instance"
+        permissions  = ["applicationInstancePermissionGrantAccess"]
+      },
+    ]
   }
 }

--- a/internal/testdata/console/application_group_v1/resource_create_no_instance_permissions.tf
+++ b/internal/testdata/console/application_group_v1/resource_create_no_instance_permissions.tf
@@ -1,0 +1,19 @@
+
+resource "conduktor_console_application_group_v1" "test" {
+  name        = "myappgroup"
+  application = "myapp"
+  spec = {
+    display_name    = "My Application Group"
+    description     = "test"
+    external_groups = ["mygroup"]
+    permissions = [
+      {
+        app_instance  = "my-app-instance"
+        resource_type = "TOPIC"
+        pattern_type  = "LITERAL"
+        name          = "*"
+        permissions   = ["topicViewConfig"]
+      },
+    ]
+  }
+}

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -928,6 +928,67 @@
                       ]
                     }
                   }
+                },
+                {
+                  "name": "instance_permissions",
+                  "set_nested": {
+                    "description": "Set of instance-level permissions granted to this group on application instances",
+                    "computed_optional_required": "computed_optional",
+                    "nested_object": {
+                      "attributes": [
+                        {
+                          "name": "app_instance",
+                          "string": {
+                            "description": "Reference to the application instance",
+                            "computed_optional_required": "required",
+                            "validators": [
+                              {
+                                "custom": {
+                                  "imports": [
+                                    {
+                                      "path": "regexp"
+                                    },
+                                    {
+                                      "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+                                    }
+                                  ],
+                                  "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "name": "permissions",
+                          "set": {
+                            "description": "Set of instance-level permissions to grant. Valid values are: applicationInstancePermissionRequestAccess, applicationInstancePermissionGrantAccess, applicationInstanceApiKeyManage, applicationInstancePermissionProposeAccess, serviceAccountManage",
+                            "computed_optional_required": "optional",
+                            "element_type": {
+                              "string": {}
+                            },
+                            "validators": [
+                              {
+                                "custom": {
+                                  "imports": [
+                                    {
+                                      "path": "github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+                                    },
+                                    {
+                                      "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+                                    },
+                                    {
+                                      "path": "github.com/conduktor/terraform-provider-conduktor/internal/schema/validation"
+                                    }
+                                  ],
+                                  "schema_definition": "setvalidator.ValueStringsAre(stringvalidator.OneOf(validation.ValidAppGroupInstancePermissions ...))"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
                 }
               ]
             }


### PR DESCRIPTION
This pull request adds support for managing instance-level permissions on application groups, allowing users to specify granular permissions for specific application instances. The changes include updates to the resource schema, internal models, mapping logic, validation, documentation, and tests to support the new `instance_permissions` attribute.

**Schema and Validation Updates:**
- Added a new `instance_permissions` attribute to the application group resource schema, including nested attributes for `app_instance` and `permissions`, with validation for allowed permission values. 

**Internal Model and Mapping Logic:**
- Introduced the `ApplicationGroupInstancePermission` struct and updated the internal `ApplicationGroupSpec` to include an `InstancePermissions` field.
- Implemented conversion functions between Terraform and internal models for `instance_permissions`, ensuring proper mapping in both directions.

**Documentation:**
- Updated provider documentation to describe the new `instance_permissions` attribute and its nested schema.

**Testing:**
- Extended unit and acceptance tests to verify correct handling and mapping of `instance_permissions`. 