### PR TITLE
Added default for instance_permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ website/vendor
 
 # ingore binary build
 terraform-provider-conduktor
+
+# local manual testing sandbox
+local-test/

--- a/internal/schema/resource_console_application_group_v1/console_application_group_v1_resource_gen.go
+++ b/internal/schema/resource_console_application_group_v1/console_application_group_v1_resource_gen.go
@@ -105,6 +105,7 @@ func ConsoleApplicationGroupV1ResourceSchema(ctx context.Context) schema.Schema 
 						Computed:            true,
 						Description:         "Set of instance-level permissions granted to this group on application instances",
 						MarkdownDescription: "Set of instance-level permissions granted to this group on application instances",
+						Default:             setdefault.StaticValue(types.SetValueMust(InstancePermissionsValue{}.Type(ctx), []attr.Value{})),
 					},
 					"members": schema.SetAttribute{
 						ElementType:         types.StringType,

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -987,6 +987,19 @@
                           }
                         }
                       ]
+                    },
+                    "default": {
+                      "custom": {
+                        "imports": [
+                          {
+                            "path": "github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+                          },
+                          {
+                            "path": "github.com/hashicorp/terraform-plugin-framework/types"
+                          }
+                        ],
+                        "schema_definition": "setdefault.StaticValue(types.SetValueMust(InstancePermissionsValue{}.Type(ctx), []attr.Value{}))"
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
This pull request introduces a default value for the `instance_permissions` attribute in the `ConsoleApplicationGroupV1ResourceSchema`. The main changes ensure that this attribute is always initialized with an empty set if not explicitly provided, improving resource schema consistency and reducing the chance of nil errors.

Schema default value improvements:

* Added a default value for the `instance_permissions` attribute in `console_application_group_v1_resource_gen.go` using `setdefault.StaticValue` to ensure it defaults to an empty set.
* Updated `provider_code_spec.json` to reflect the new default value and its implementation details, including necessary imports for `setdefault` and `types`.