### PR TITLE
Skip checkEnterprisePlanRequirement check if console use api key auth method

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -23,9 +23,20 @@ const (
 	GATEWAY Mode = "Gateway"
 )
 
+// AuthMethod records how a Client authenticated, so callers can reason about
+// which APIs are reachable (e.g. the internal /organizations endpoints are only
+// available with credential auth, not with an API key).
+type AuthMethod string
+
+const (
+	AuthMethodApiKey      AuthMethod = "api_key"
+	AuthMethodCredentials AuthMethod = "credentials"
+)
+
 type Client struct {
-	BaseUrl string
-	Client  *resty.Client
+	BaseUrl    string
+	Client     *resty.Client
+	AuthMethod AuthMethod
 }
 
 type LoginResult struct {
@@ -63,9 +74,15 @@ func Make(ctx context.Context, mode Mode, apiParameter ApiParameter, providerVer
 	// Enable http client debug logs when provider log is set to TRACE
 	restyClient.SetDebug(TraceLogEnabled())
 
+	authMethod := AuthMethodCredentials
+	if mode == CONSOLE && apiParameter.ApiKey != "" {
+		authMethod = AuthMethodApiKey
+	}
+
 	return &Client{
-		BaseUrl: apiParameter.BaseUrl,
-		Client:  restyClient,
+		BaseUrl:    apiParameter.BaseUrl,
+		Client:     restyClient,
+		AuthMethod: authMethod,
 	}, nil
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -55,6 +55,35 @@ func TestGetConsoleLicensePlan_NoDoubleApiPrefix(t *testing.T) {
 	}
 }
 
+func TestMakeAuthMethod(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Console credential auth logs in against /login before any resource call.
+		if r.URL.Path == "/api/login" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "minted-token"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	apiKeyClient, err := Make(context.Background(), CONSOLE, ApiParameter{BaseUrl: ts.URL, ApiKey: "test-key"}, "test")
+	if err != nil {
+		t.Fatalf("failed to create api-key client: %v", err)
+	}
+	if apiKeyClient.AuthMethod != AuthMethodApiKey {
+		t.Errorf("expected AuthMethodApiKey, got %q", apiKeyClient.AuthMethod)
+	}
+
+	credClient, err := Make(context.Background(), CONSOLE, ApiParameter{BaseUrl: ts.URL, CdkUser: "admin", CdkPassword: "secret"}, "test")
+	if err != nil {
+		t.Fatalf("failed to create credential client: %v", err)
+	}
+	if credClient.AuthMethod != AuthMethodCredentials {
+		t.Errorf("expected AuthMethodCredentials, got %q", credClient.AuthMethod)
+	}
+}
+
 func TestUniformizeBaseUrl(t *testing.T) {
 	cases := []struct {
 		input    string

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -210,6 +210,12 @@ func New(version, commit, date string) func() provider.Provider {
 // - On error fetching the plan: adds a warning diagnostic (graceful degradation).
 // Callers should check resp.Diagnostics.HasError() after calling this function.
 func checkEnterprisePlanRequirement(ctx context.Context, apiClient *client.Client, consoleVersion string, enterpriseOnlyVersion string, diagnostics *diag.Diagnostics) { //nolint:unparam // enterpriseOnlyVersion is parameterized for future per-resource version flexibility
+	// TODO remove this guard when a public API endpoint exposes the license plan for API tokens.
+	if apiClient.AuthMethod != client.AuthMethodCredentials {
+		tflog.Debug(ctx, "Skipping Console license plan check: not available with API token authentication. The API will still enforce the Enterprise license requirement at apply time.")
+		return
+	}
+
 	consolePlan, err := apiClient.GetConsoleLicensePlan(ctx)
 	if err != nil {
 		diagnostics.AddWarning(


### PR DESCRIPTION
Implement workaround on `checkEnterprisePlanRequirement` to skip check if Console use API token as authentication method. 

### Context 
To have better helpful error message and avoid unnecessary API calls provider check Console license plan and version to restrict unsupported resources on configure phase. But to do that we currently use internal endpoints that don't support API token authentification. So until we have new public API endpoint that support all authentication methods we will skip this check and rely on API 403 response for unsupported resources. 

Fix #195 / CUS-992