### PR TITLE
fix(console_resource_policy_v1): make rules optional to match API

### DIFF
--- a/docs/resources/console_resource_policy_v1.md
+++ b/docs/resources/console_resource_policy_v1.md
@@ -74,12 +74,12 @@ resource "conduktor_console_resource_policy_v1" "complex" {
 
 Required:
 
-- `rules` (Attributes Set) Set of all rules to apply on the resource. (see [below for nested schema](#nestedatt--spec--rules))
 - `target_kind` (String) Type of the resource to apply policy on. Valid values are: ApplicationGroup, Connector, Subject, Topic
 
 Optional:
 
 - `description` (String) Description of the resource policy
+- `rules` (Attributes Set) Set of all rules to apply on the resource. (see [below for nested schema](#nestedatt--spec--rules))
 
 <a id="nestedatt--spec--rules"></a>
 ### Nested Schema for `spec.rules`

--- a/internal/model/console/resource_policy_v1.go
+++ b/internal/model/console/resource_policy_v1.go
@@ -28,7 +28,7 @@ type ResourcePolicyConsoleRule struct {
 type ResourcePolicyConsoleSpec struct {
 	TargetKind  string                      `json:"targetKind"`
 	Description string                      `json:"description,omitempty"`
-	Rules       []ResourcePolicyConsoleRule `json:"rules"`
+	Rules       []ResourcePolicyConsoleRule `json:"rules,omitempty"`
 }
 
 type ResourcePolicyConsoleResource struct {

--- a/internal/schema/resource_console_resource_policy_v1/console_resource_policy_v1_resource_gen.go
+++ b/internal/schema/resource_console_resource_policy_v1/console_resource_policy_v1_resource_gen.go
@@ -68,7 +68,7 @@ func ConsoleResourcePolicyV1ResourceSchema(ctx context.Context) schema.Schema {
 								},
 							},
 						},
-						Required:            true,
+						Optional:            true,
 						Description:         "Set of all rules to apply on the resource.",
 						MarkdownDescription: "Set of all rules to apply on the resource.",
 					},

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -2990,7 +2990,7 @@
                   "name": "rules",
                   "set_nested": {
                     "description": "Set of all rules to apply on the resource.",
-                    "computed_optional_required": "required",
+                    "computed_optional_required": "optional",
                     "nested_object": {
                       "attributes": [
                         {


### PR DESCRIPTION
## Summary

- `rules` in `ResourcePolicySpec` is optional in the Console API (only `targetKind` is required), but was incorrectly marked as `required` in the TF schema
- Changed `provider_code_spec.json` to `optional`, regenerated schema, and added `omitempty` to the model's `Rules` JSON tag so empty rule sets aren't sent in API payloads

## Test Plan
- [x] Mapper unit tests pass (`go test ./internal/mapper/console_resource_policy_v1/...`)
- [x] Lint clean (`make go-lint`)
- [x] Acceptance test with a resource policy that has no rules
