### PR TITLE
docs: note default platform permissions on console_user_v2 /

### DIFF
--- a/docs/resources/console_group_v2.md
+++ b/docs/resources/console_group_v2.md
@@ -11,6 +11,8 @@ description: |-
 Resource for managing Conduktor groups.
 This resource allows you to create, read, update and delete groups in Conduktor.
 
+~> **Default platform permissions:** When a user first signs in through SSO or LDAP, Console automatically grants a set of default `PLATFORM` view permissions: `userView`, `datamaskingView`, `taasView` and `notificationChannelView`. Groups (and users) created through Terraform or the API do **not** receive these automatically. To grant them to a Terraform-managed group, declare them explicitly in `spec.permissions`. `notificationChannelView` requires provider `v1.4.0` or later.
+
 ## Example Usage
 
 ### Simple group without members or permissions

--- a/docs/resources/console_user_v2.md
+++ b/docs/resources/console_user_v2.md
@@ -11,6 +11,8 @@ description: |-
 Resource for managing Conduktor users.
 This resource allows you to create, read, update and delete users in Conduktor.
 
+~> **Default platform permissions:** When a user first signs in through SSO or LDAP, Console automatically grants a set of default `PLATFORM` view permissions: `userView`, `datamaskingView`, `taasView` and `notificationChannelView`. Users created through Terraform or the API do **not** receive these automatically. To make a Terraform-managed user match one created via SSO/LDAP login, declare them explicitly in `spec.permissions`. `notificationChannelView` requires provider `v1.4.0` or later.
+
 ## Example Usage
 
 ### Simple user without permissions

--- a/templates/resources/console_group_v2.md.tmpl
+++ b/templates/resources/console_group_v2.md.tmpl
@@ -11,6 +11,8 @@ description: |-
 Resource for managing Conduktor groups.
 This resource allows you to create, read, update and delete groups in Conduktor.
 
+~> **Default platform permissions:** When a user first signs in through SSO or LDAP, Console automatically grants a set of default `PLATFORM` view permissions: `userView`, `datamaskingView`, `taasView` and `notificationChannelView`. Groups (and users) created through Terraform or the API do **not** receive these automatically. To grant them to a Terraform-managed group, declare them explicitly in `spec.permissions`. `notificationChannelView` requires provider `v1.4.0` or later.
+
 ## Example Usage
 
 ### Simple group without members or permissions

--- a/templates/resources/console_user_v2.md.tmpl
+++ b/templates/resources/console_user_v2.md.tmpl
@@ -11,6 +11,8 @@ description: |-
 Resource for managing Conduktor users.
 This resource allows you to create, read, update and delete users in Conduktor.
 
+~> **Default platform permissions:** When a user first signs in through SSO or LDAP, Console automatically grants a set of default `PLATFORM` view permissions: `userView`, `datamaskingView`, `taasView` and `notificationChannelView`. Users created through Terraform or the API do **not** receive these automatically. To make a Terraform-managed user match one created via SSO/LDAP login, declare them explicitly in `spec.permissions`. `notificationChannelView` requires provider `v1.4.0` or later.
+
 ## Example Usage
 
 ### Simple user without permissions


### PR DESCRIPTION
  _group_v2 [CUS-880]

SSO/LDAP login auto-grants the default PLATFORM view permissions (userView, datamaskingView, taasView,
  notificationChannelView), but Terraform/API-created users and groups do not receive them and must declare them explicitly.
  notificationChannelView requires provider v1.4.0+ (added to the accepted permission values in #203).