### PR TITLE
fix(schema): align console resource name regex with API spec

### DIFF
--- a/internal/schema/resource_console_application_group_v1/console_application_group_v1_resource_gen.go
+++ b/internal/schema/resource_console_application_group_v1/console_application_group_v1_resource_gen.go
@@ -32,7 +32,7 @@ func ConsoleApplicationGroupV1ResourceSchema(ctx context.Context) schema.Schema 
 				Description:         "Reference to the application this group belongs to",
 				MarkdownDescription: "Reference to the application this group belongs to",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"name": schema.StringAttribute{
@@ -43,7 +43,7 @@ func ConsoleApplicationGroupV1ResourceSchema(ctx context.Context) schema.Schema 
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"spec": schema.SingleNestedAttribute{
@@ -82,7 +82,7 @@ func ConsoleApplicationGroupV1ResourceSchema(ctx context.Context) schema.Schema 
 									Description:         "Reference to the application instance",
 									MarkdownDescription: "Reference to the application instance",
 									Validators: []validator.String{
-										stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+										stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 									},
 								},
 								"permissions": schema.SetAttribute{
@@ -133,7 +133,7 @@ func ConsoleApplicationGroupV1ResourceSchema(ctx context.Context) schema.Schema 
 									Description:         "Reference to the application instance this group belongs to",
 									MarkdownDescription: "Reference to the application instance this group belongs to",
 									Validators: []validator.String{
-										stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+										stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 									},
 								},
 								"connect_cluster": schema.StringAttribute{

--- a/internal/schema/resource_console_application_instance_permission_v1/console_application_instance_permission_v1_resource_gen.go
+++ b/internal/schema/resource_console_application_instance_permission_v1/console_application_instance_permission_v1_resource_gen.go
@@ -30,7 +30,7 @@ func ConsoleApplicationInstancePermissionV1ResourceSchema(ctx context.Context) s
 				Description:         "Reference to the application instance this permission belongs to",
 				MarkdownDescription: "Reference to the application instance this permission belongs to",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"application": schema.StringAttribute{
@@ -38,7 +38,7 @@ func ConsoleApplicationInstancePermissionV1ResourceSchema(ctx context.Context) s
 				Description:         "Reference to the application this permission belongs to",
 				MarkdownDescription: "Reference to the application this permission belongs to",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"name": schema.StringAttribute{
@@ -49,7 +49,7 @@ func ConsoleApplicationInstancePermissionV1ResourceSchema(ctx context.Context) s
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"spec": schema.SingleNestedAttribute{
@@ -59,7 +59,7 @@ func ConsoleApplicationInstancePermissionV1ResourceSchema(ctx context.Context) s
 						Description:         "Reference to an application instance. Must be on the same Kafka cluster as app_instance",
 						MarkdownDescription: "Reference to an application instance. Must be on the same Kafka cluster as app_instance",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+							stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 						},
 					},
 					"resource": schema.SingleNestedAttribute{

--- a/internal/schema/resource_console_application_instance_v1/console_application_instance_v1_resource_gen.go
+++ b/internal/schema/resource_console_application_instance_v1/console_application_instance_v1_resource_gen.go
@@ -29,7 +29,7 @@ func ConsoleApplicationInstanceV1ResourceSchema(ctx context.Context) schema.Sche
 				Description:         "Reference to the application this instance belongs to",
 				MarkdownDescription: "Reference to the application this instance belongs to",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"name": schema.StringAttribute{
@@ -40,7 +40,7 @@ func ConsoleApplicationInstanceV1ResourceSchema(ctx context.Context) schema.Sche
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"spec": schema.SingleNestedAttribute{

--- a/internal/schema/resource_console_application_v1/console_application_v1_resource_gen.go
+++ b/internal/schema/resource_console_application_v1/console_application_v1_resource_gen.go
@@ -31,7 +31,7 @@ func ConsoleApplicationV1ResourceSchema(ctx context.Context) schema.Schema {
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"spec": schema.SingleNestedAttribute{

--- a/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
+++ b/internal/schema/resource_console_group_v2/console_group_v2_resource_gen.go
@@ -35,7 +35,7 @@ func ConsoleGroupV2ResourceSchema(ctx context.Context) schema.Schema {
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"spec": schema.SingleNestedAttribute{

--- a/internal/schema/resource_console_partner_zone_v2/console_partner_zone_v2_resource_gen.go
+++ b/internal/schema/resource_console_partner_zone_v2/console_partner_zone_v2_resource_gen.go
@@ -38,7 +38,7 @@ func ConsolePartnerZoneV2ResourceSchema(ctx context.Context) schema.Schema {
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"spec": schema.SingleNestedAttribute{

--- a/internal/schema/resource_console_resource_policy_v1/console_resource_policy_v1_resource_gen.go
+++ b/internal/schema/resource_console_resource_policy_v1/console_resource_policy_v1_resource_gen.go
@@ -38,7 +38,7 @@ func ConsoleResourcePolicyV1ResourceSchema(ctx context.Context) schema.Schema {
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"spec": schema.SingleNestedAttribute{

--- a/internal/schema/resource_console_service_account_v1/console_service_account_v1_resource_gen.go
+++ b/internal/schema/resource_console_service_account_v1/console_service_account_v1_resource_gen.go
@@ -30,7 +30,7 @@ func ConsoleServiceAccountV1ResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Reference to the application instance this service account is associated with",
 				MarkdownDescription: "Reference to the application instance this service account is associated with",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"cluster": schema.StringAttribute{
@@ -52,7 +52,7 @@ func ConsoleServiceAccountV1ResourceSchema(ctx context.Context) schema.Schema {
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"spec": schema.SingleNestedAttribute{

--- a/internal/schema/resource_console_topic_policy_v1/console_topic_policy_v1_resource_gen.go
+++ b/internal/schema/resource_console_topic_policy_v1/console_topic_policy_v1_resource_gen.go
@@ -31,7 +31,7 @@ func ConsoleTopicPolicyV1ResourceSchema(ctx context.Context) schema.Schema {
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-]+$"), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-z\\_\\-.]+$"), ""),
 				},
 			},
 			"spec": schema.SingleNestedAttribute{

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -120,7 +120,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -191,7 +191,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -213,7 +213,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -235,7 +235,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -374,7 +374,7 @@
                               "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                             }
                           ],
-                          "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                          "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                         }
                       }
                     ]
@@ -430,7 +430,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -452,7 +452,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -668,7 +668,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -690,7 +690,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -833,7 +833,7 @@
                                       "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                                     }
                                   ],
-                                  "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                                  "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                                 }
                               }
                             ]
@@ -952,7 +952,7 @@
                                       "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                                     }
                                   ],
-                                  "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                                  "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                                 }
                               }
                             ]
@@ -1241,7 +1241,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -2637,7 +2637,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -2935,7 +2935,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -3049,7 +3049,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -3071,7 +3071,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]
@@ -3696,7 +3696,7 @@
                         "path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
                       }
                     ],
-                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-]+$\"), \"\")"
+                    "schema_definition": "stringvalidator.RegexMatches(regexp.MustCompile(\"^[0-9a-z\\\\_\\\\-.]+$\"), \"\")"
                   }
                 }
               ]


### PR DESCRIPTION
## Summary

- All console resource name/reference fields now use `^[0-9a-z_\-.]+$` (allowing dots) to match the `pattern` constraints defined in the Console 1.46.2 OpenAPI spec
- Previously these validators were using `^[0-9a-z_\-]+$` (no dot), which would incorrectly reject valid resource names containing periods
- Gateway resources were checked against the Gateway 3.20.0 v2 spec — no changes needed (spec defines no pattern constraints on path parameters)

**Affected console resources:**
- `console_application_v1` — `name`
- `console_application_instance_permission_v1` — `name`, `application`, `app_instance`, `granted_to`
- `console_application_instance_v1` — `name`, `application`
- `console_application_group_v1` — `name`, `application`, `app_instance`
- `console_group_v2` — `name`
- `console_partner_zone_v2` — `name`
- `console_resource_policy_v1` — `name`
- `console_service_account_v1` — `name`, `app_instance`
- `console_topic_policy_v1` — `name`

## Test Plan

- [x] All mapper unit tests pass (`go test ./internal/mapper/...`)
- [x] Provider builds cleanly (`make build`)
- [x] `make generate` regenerates schema files cleanly from updated `provider_code_spec.json`
- [x] Acceptance tests against live Console environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)