### PR TITLE
Fix client GetAPIVersion for Gateway to use /versions endpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           # minimal versions no license
           - console: "1.26.0"
-            gateway: "3.5.2"
+            gateway: "3.11.0"
             terraform:
               version: "1.0.*"
               name: "TF-1.0"
@@ -75,7 +75,7 @@ jobs:
 
           # minimal versions with license
           - console: "1.26.0"
-            gateway: "3.5.2"
+            gateway: "3.11.0"
             terraform:
               version: "1.0.*"
               name: "TF-1.0"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository contains the Conduktor Terraform provider, which defines Condukt
 > The Conduktor Terraform provider may not include the latest features. [Check out all the supported resources](https://docs.conduktor.io/guide/conduktor-in-production/automate).
 > [Find out how to use and configure the Conduktor provider](https://registry.terraform.io/providers/conduktor/conduktor/latest/docs).
 
-### Minimal version supported by current provider
+## Minimal versions supported
 
 * Terraform : [1.0.0](https://developer.hashicorp.com/terraform/enterprise/releases/1.0.x#1-0-0)
 * Conduktor Console : [1.26.0](https://docs.conduktor.io/guide/release-notes/archive#console-1-26-0)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ This repository contains the Conduktor Terraform provider, which defines Condukt
 > The Conduktor Terraform provider may not include the latest features. [Check out all the supported resources](https://docs.conduktor.io/guide/conduktor-in-production/automate).
 > [Find out how to use and configure the Conduktor provider](https://registry.terraform.io/providers/conduktor/conduktor/latest/docs).
 
+### Minimal version supported by current provider
+
+* Terraform : [1.0.0](https://developer.hashicorp.com/terraform/enterprise/releases/1.0.x#1-0-0)
+* Conduktor Console : [1.26.0](https://docs.conduktor.io/guide/release-notes/archive#console-1-26-0)
+* Condukor Gateway : [3.11.0](https://docs.conduktor.io/guide/release-notes?tags=Gateway#gateway-3-11-0)
+
 ## Install
 
 Provider should be installed automatically with `terraform init`, but it's recommended to pin a specific version or range of versions using the following [`required_providers` configuration](https://developer.hashicorp.com/terraform/language/providers/requirements) :

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,11 @@ The Conduktor provider is used to interact with the resources supported by Condu
  - The Conduktor Terraform provider may not include the latest features. [Check out all the supported resources](https://docs.conduktor.io/guide/conduktor-in-production/automate).
  - You can also [request a feature](https://conduktor.io/roadmap).
 
+## Minimal versions supported
+
+* Conduktor Console : [1.26.0](https://docs.conduktor.io/guide/release-notes/archive#console-1-26-0)
+* Condukor Gateway : [3.11.0](https://docs.conduktor.io/guide/release-notes?tags=Gateway#gateway-3-11-0)
+
 ## Example Usage
 
 ### Console client only

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -301,7 +301,7 @@ func (client *Client) GetAPIVersion(ctx context.Context, mode Mode) (string, err
 		path = "/versions"
 	}
 	if mode == GATEWAY {
-		path = "/health"
+		path = "/versions"
 	}
 
 	url := client.BaseUrl + path
@@ -328,27 +328,9 @@ func (client *Client) GetAPIVersion(ctx context.Context, mode Mode) (string, err
 		}
 	}
 	if mode == GATEWAY {
-		// This is a temporary workaround for the Gateway API till a dedicated endpoint is available.
-		checks, ok := result["checks"].([]any)
-		if !ok || len(checks) == 0 {
-			return "", fmt.Errorf("no checks found in response")
-		}
-		for _, check := range checks {
-			// Need to assert check to map[string]any to access its fields.
-			id, ok := check.(map[string]any)["id"]
-			if !ok {
-				return "", fmt.Errorf("error parsing check ID")
-			}
-			if id == "buildInfo" {
-				data, ok := check.(map[string]any)["data"]
-				if !ok {
-					return "", fmt.Errorf("no data found in checks response")
-				}
-				v, ok = data.(map[string]any)["version"]
-				if !ok {
-					return "", fmt.Errorf("no version found in data response")
-				}
-			}
+		v, ok = result["gateway"]
+		if !ok {
+			return "", fmt.Errorf("no version found in response")
 		}
 	}
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -13,6 +13,11 @@ The Conduktor provider is used to interact with the resources supported by Condu
  - The Conduktor Terraform provider may not include the latest features. [Check out all the supported resources](https://docs.conduktor.io/guide/conduktor-in-production/automate).
  - You can also [request a feature](https://conduktor.io/roadmap).
 
+## Minimal versions supported
+
+* Conduktor Console : [1.26.0](https://docs.conduktor.io/guide/release-notes/archive#console-1-26-0)
+* Condukor Gateway : [3.11.0](https://docs.conduktor.io/guide/release-notes?tags=Gateway#gateway-3-11-0)
+
 ## Example Usage
 
 ### Console client only


### PR DESCRIPTION
- Update client.GetAPIVersion to lookup to /versions endpoint to get Gateway current version. 
- Bump minimal supported Gateway version to 3.11.0 (when /versions was introduced)
- Add "Minimal version supported" section on provider README and generated docs